### PR TITLE
Glue scheduling

### DIFF
--- a/src/handlers/site_upload/powerset_merge.py
+++ b/src/handlers/site_upload/powerset_merge.py
@@ -152,13 +152,13 @@ def merge_powersets(
 
     csv_aggregate_path = (
         f"s3://{s3_bucket_name}/{BucketPath.CSVAGGREGATE.value}/"
-        f"{study}/{subscription}/{study}_{subscription}_aggregate.csv"
+        f"{study}/{study}_{subscription}/{study}_{subscription}_aggregate.csv"
     )
     df = df.apply(lambda x: x.strip() if isinstance(x, str) else x).replace('""', nan)
     awswrangler.s3.to_csv(df, csv_aggregate_path, index=False, quoting=csv.QUOTE_NONE)
     aggregate_path = (
         f"s3://{s3_bucket_name}/{BucketPath.AGGREGATE.value}/"
-        f"{study}/{subscription}/{study}_{subscription}_aggregate.parquet"
+        f"{study}/{study}_{subscription}/{study}_{subscription}_aggregate.parquet"
     )
     # Note: the to_parquet function is noted in the docs as potentially mutating the
     # dataframe it's called on, so this should always be the last action applied

--- a/template.yaml
+++ b/template.yaml
@@ -201,16 +201,20 @@ Resources:
       SchemaChangePolicy:
         DeleteBehavior: DEPRECATE_IN_DATABASE
         UpdateBehavior: UPDATE_IN_DATABASE
+      Schedule:
+        ScheduleExpression: "cron(0 22 ? * SUN *)"
       Targets:
         S3Targets:
           - Path: !Ref AggregatorBucket
           - Exclusions: 
-            - site_upload/**
-            - latest/**
-            - last_valid/**
-            - error/**
+            - aggregates/**
+            - athena/**
             - csv_aggregates/**
-            - metadata/**
+            - error/**
+            - last_valid/**
+            - latest/**
+            - site_metadata/**
+            - site_upload/**
 
 
 


### PR DESCRIPTION
This PR makes the following changes:
- Glue crawler now has a scheduled run
- Adjusted aggregate folder name to prevent athena namespace issues
- Alphasorted the bucket exculde list