### PR TITLE
API keys for public dashboard API

### DIFF
--- a/MAINTAINER.md
+++ b/MAINTAINER.md
@@ -20,6 +20,7 @@ To create a new user, you would need to run the following two commands:
 
 Creating a user:
 `./scripts/cumulus_upload_data.py --ca user_name auth_secret site_short_name`
+
 Associating a site with an s3 directory:
 `./scripts/cumulus_upload_data.py --cm site_short_name s3_folder_name`
 

--- a/docs/dashboard_api.prod.yaml
+++ b/docs/dashboard_api.prod.yaml
@@ -26,6 +26,8 @@ paths:
         required: true
         schema:
           type: "string"
+      security:
+      - api_key: []
     options:
       parameters:
       - name: "study"
@@ -57,8 +59,12 @@ paths:
               schema:
                 type: "string"
           content: {}
+      security:
+      - api_key: []
   /data_packages:
-    get: {}
+    get:
+      security:
+      - api_key: []
     options:
       responses:
         "200":
@@ -74,8 +80,12 @@ paths:
               schema:
                 type: "string"
           content: {}
+      security:
+      - api_key: []
   /metadata:
-    get: {}
+    get:
+      security:
+      - api_key: []
     options:
       responses:
         "200":
@@ -91,6 +101,8 @@ paths:
               schema:
                 type: "string"
           content: {}
+      security:
+      - api_key: []
   /chart-data/{subscription_name}:
     get:
       parameters:
@@ -99,6 +111,8 @@ paths:
         required: true
         schema:
           type: "string"
+      security:
+      - api_key: []
     options:
       parameters:
       - name: "subscription_name"
@@ -120,6 +134,8 @@ paths:
               schema:
                 type: "string"
           content: {}
+      security:
+      - api_key: []
   /study-periods/{site}:
     get:
       parameters:
@@ -128,6 +144,8 @@ paths:
         required: true
         schema:
           type: "string"
+      security:
+      - api_key: []
     options:
       parameters:
       - name: "site"
@@ -149,6 +167,8 @@ paths:
               schema:
                 type: "string"
           content: {}
+      security:
+      - api_key: []
   /metadata/{site}/{study}:
     get:
       parameters:
@@ -162,6 +182,8 @@ paths:
         required: true
         schema:
           type: "string"
+      security:
+      - api_key: []
     options:
       parameters:
       - name: "study"
@@ -188,6 +210,8 @@ paths:
               schema:
                 type: "string"
           content: {}
+      security:
+      - api_key: []
   /metadata/{site}:
     get:
       parameters:
@@ -196,6 +220,8 @@ paths:
         required: true
         schema:
           type: "string"
+      security:
+      - api_key: []
     options:
       parameters:
       - name: "site"
@@ -217,6 +243,8 @@ paths:
               schema:
                 type: "string"
           content: {}
+      security:
+      - api_key: []
   /study-periods/{site}/{study}:
     get:
       parameters:
@@ -230,6 +258,8 @@ paths:
         required: true
         schema:
           type: "string"
+      security:
+      - api_key: []
     options:
       parameters:
       - name: "study"
@@ -256,8 +286,12 @@ paths:
               schema:
                 type: "string"
           content: {}
+      security:
+      - api_key: []
   /study-periods:
-    get: {}
+    get:
+      security:
+      - api_key: []
     options:
       responses:
         "200":
@@ -273,5 +307,11 @@ paths:
               schema:
                 type: "string"
           content: {}
-components: {}
-
+      security:
+      - api_key: []
+components:
+  securitySchemes:
+    api_key:
+      type: "apiKey"
+      name: "x-api-key"
+      in: "header"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -58,7 +58,7 @@ s3_prefix = "cumulus-aggregator-dev"
 region = "us-east-1"
 confirm_changeset = true
 capabilities = "CAPABILITY_IAM"
-parameter_overrides = "DeployStage=\"dev\" AggregatorDomainName=\"dev.aggregator.yourdomain.org\" AggregatorHostedZoneID=\"1234567890ABCDEFHIJ\" AggregatorCertArn=\"arn:aws:acm:us-east-1:1234567890:certificate/12345678-90AB-CDEF-0123-4567890ABCD\""
+parameter_overrides = "RetentionTime=7 DeployStage=\"dev\" AggregatorDomainName=\"dev.aggregator.yourdomain.org\" AggregatorHostedZoneID=\"1234567890ABCDEFHIJ\" AggregatorCertArn=\"arn:aws:acm:us-east-1:1234567890:certificate/12345678-90AB-CDEF-0123-4567890ABCD\" DashboardApiDomainName=\"dev.api.yourdomain.org\" DashboardApiCertArn=\"arn:aws:acm:us-east-1:1234567890:certificate/11112222-3333-CDEF-0123-FECDBA0987654\""
 image_repositories = []
 
 [staging]
@@ -70,14 +70,14 @@ s3_prefix = "cumulus-aggregator-staging"
 region = "us-east-1"
 confirm_changeset = true
 capabilities = "CAPABILITY_IAM"
-parameter_overrides = "DeployStage=\"staging\" AggregatorDomainName=\"staging.aggregator.yourdomain.org\" AggregatorHostedZoneID=\"1234567890ABCDEFHIJ\" AggregatorCertArn=\"aarn:aws:acm:us-east-1:1234567890:certificate/12345678-90AB-CDEF-0123-FECDBA0987654\""
+parameter_overrides = "RetentionTime=7 DeployStage=\"staging\" AggregatorDomainName=\"staging.aggregator.yourdomain.org\" AggregatorHostedZoneID=\"1234567890ABCDEFHIJ\" AggregatorCertArn=\"aarn:aws:acm:us-east-1:1234567890:certificate/12345678-90AB-CDEF-0123-FECDBA0987654\" DashboardApiDomainName=\"staging.api.yourdomain.org\" DashboardApiCertArn=\"arn:aws:acm:us-east-1:1234567890:certificate/11112222-3333-CDEF-0123-FECDBA0987654\""
 image_repositories = []
 ```
 Note that you'll use the same hosted zone for each stage, but a different certificate arn, one per environment. If you skipped external domain setup, just omit those entries
 
 
 If for some reason you don't want to use the samconfig.toml, you could instead do these things, but it's much more error-prone, so please be careful:
-- Add default parameters for `AggregatorCertArn`, `AggregatorHostedZoneID`, `DeployStage`, and `AggregatorHostedDomainName` (if using)
+- Add default parameters for `RetentionTime`, `AggregatorCertArn`, `AggregatorHostedZoneID`, `DashboardApiCertArn`, `DeployStage`, and if using, `AggregatorHostedDomainName` and `DashboardApiDomainName`
 - Create environment variables and assign values to those parameters. Then, whenever you run `sam`, provide a parameter override in place of `--config-env`, with `--parameter-overrides AggregatorCertArn=$CUMULUS_AGG_CERT_ARN AggregatorHostedZoneID=$CUMULUS_AGG_ZONE_ID` (and deploy/domain if using.
 
 
@@ -119,7 +119,7 @@ s3_prefix = "cumulus-aggregator-dev"
 region = "us-east-1"
 confirm_changeset = true
 capabilities = "CAPABILITY_IAM CAPABILITY_NAMED_IAM"
-parameter_overrides = "DeployStage=\"dev\" AggregatorDomainName=\"dev.aggregator.yourdomain.org\" AggregatorHostedZoneID=\"1234567890ABCDEFHIJ\" AggregatorCertArn=\"arn:aws:acm:us-east-1:1234567890:certificate/12345678-90AB-CDEF-0123-4567890ABCD\""
+parameter_overrides = "RetentionTime=7 DeployStage=\"dev\" AggregatorDomainName=\"dev.aggregator.yourdomain.org\" AggregatorHostedZoneID=\"1234567890ABCDEFHIJ\" AggregatorCertArn=\"arn:aws:acm:us-east-1:1234567890:certificate/12345678-90AB-CDEF-0123-4567890ABCD\" DashboardApiDomainName=\"dev.api.yourdomain.org\" DashboardApiCertArn=\"arn:aws:acm:us-east-1:1234567890:certificate/11112222-3333-CDEF-0123-FECDBA0987654\""
 image_repositories = []
 
 ```

--- a/template.hostedzone.yaml
+++ b/template.hostedzone.yaml
@@ -89,6 +89,33 @@ Resources:
           HostedZoneId: !Ref CumulusHostedZone
       ValidationMethod: DNS
 
+  AcmApiCertificate:
+    Type: AWS::CertificateManager::Certificate
+    Properties:
+      DomainName: !Sub "api.${Domain}"
+      DomainValidationOptions:
+        - DomainName: !Sub "api.${Domain}"
+          HostedZoneId: !Ref CumulusHostedZone
+      ValidationMethod: DNS
+
+  AcmStagingApiCertificate:
+    Type: AWS::CertificateManager::Certificate
+    Properties:
+      DomainName: !Sub "staging.api.${Domain}"
+      DomainValidationOptions:
+        - DomainName: !Sub "staging.api.${Domain}"
+          HostedZoneId: !Ref CumulusHostedZone
+      ValidationMethod: DNS
+
+  AcmDevApiCertificate:
+    Type: AWS::CertificateManager::Certificate
+    Properties:
+      DomainName: !Sub "dev.api.${Domain}"
+      DomainValidationOptions:
+        - DomainName: !Sub "dev.api.${Domain}"
+          HostedZoneId: !Ref CumulusHostedZone
+      ValidationMethod: DNS
+
 Outputs:
   RootCertificateArn:
     Description: "ACM Root Certificate ARN"
@@ -121,6 +148,18 @@ Outputs:
   AggDevCertificateArn:
     Description: "ACM Dev Aggregator Certificate ARN"
     Value: !Ref AcmDevAggCertificate
+
+  ApiCertificateArn:
+    Description: "ACM Aggregator Certificate ARN"
+    Value: !Ref AcmApiCertificate
+
+  ApiStagingCertificateArn:
+    Description: "ACM Staging Aggregator Certificate ARN"
+    Value: !Ref AcmStagingApiCertificate
+
+  ApiDevCertificateArn:
+    Description: "ACM Dev Aggregator Certificate ARN"
+    Value: !Ref AcmDevApiCertificate
 
   CumulusHostedZoneId:
     Description: "Cumulus Hosted Zone ID"

--- a/template.yaml
+++ b/template.yaml
@@ -39,10 +39,16 @@ Parameters:
       - prod
   AggregatorDomainName:
     Type: String
+  DashboardApiDomainName:
+    Type: String    
   AggregatorCertArn:
     Type: String
+  DashboardApiCertArn:
+    Type: String    
   AggregatorHostedZoneID:
     Type: String
+  RetentionTime:
+    Type: Number
 
 
 Resources:
@@ -66,7 +72,13 @@ Resources:
           REGION: !Ref "AWS::Region"
       Policies:
         - S3ReadPolicy:
-            BucketName: !Sub '${BucketNameParameter}-${DeployStage}'
+            BucketName: !Sub '${BucketNameParameter}-${DeployStage}'       
+
+  FetchAuthorizerLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties: 
+      LogGroupName: !Sub "/aws/lambda/${FetchAuthorizerFunction}"
+      RetentionInDays: !Ref RetentionTime
 
   FetchUploadUrlFunction:
     Type: AWS::Serverless::Function
@@ -92,6 +104,12 @@ Resources:
         - S3CrudPolicy:
             BucketName: !Sub '${BucketNameParameter}-${DeployStage}'
 
+  FetchUploadUrlLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties: 
+      LogGroupName: !Sub "/aws/lambda/${FetchUploadUrlFunction}"
+      RetentionInDays: !Ref RetentionTime
+
   ProcessUploadFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -113,6 +131,12 @@ Resources:
             TopicName: !GetAtt SNSTopicProcessCounts.TopicName
         - SNSPublishMessagePolicy:
             TopicName: !GetAtt SNSTopicProcessStudyMeta.TopicName
+
+  ProcessUploadLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties: 
+      LogGroupName: !Sub "/aws/lambda/${ProcessUploadFunction}"
+      RetentionInDays: !Ref RetentionTime
 
   PowersetMergeFunction:
     Type: AWS::Serverless::Function
@@ -139,6 +163,12 @@ Resources:
         - SNSPublishMessagePolicy:
             TopicName: !GetAtt SNSTopicCacheAPI.TopicName
 
+  PowersetMergeLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties: 
+      LogGroupName: !Sub "/aws/lambda/${PowersetMergeFunction}"
+      RetentionInDays: !Ref RetentionTime
+
   StudyPeriodFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -160,6 +190,12 @@ Resources:
       Policies:
         - S3CrudPolicy:
             BucketName: !Sub '${BucketNameParameter}-${DeployStage}'
+
+  StudyPeriodLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties: 
+      LogGroupName: !Sub "/aws/lambda/${StudyPeriodFunction}"
+      RetentionInDays: !Ref RetentionTime
 
   CacheAPIFunction:
     Type: AWS::Serverless::Function
@@ -200,6 +236,12 @@ Resources:
             Action:
               - athena:*
             Resource: !Sub 'arn:aws:athena:${AWS::Region}:${AWS::AccountId}:workgroup/${AthenaWorkgroupNameParameter}-${DeployStage}'
+
+  CacheAPILogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties: 
+      LogGroupName: !Sub "/aws/lambda/${CacheAPIFunction}"
+      RetentionInDays: !Ref RetentionTime
 
   # Dashboard API
 
@@ -245,6 +287,12 @@ Resources:
               - athena:*
             Resource: !Sub 'arn:aws:athena:${AWS::Region}:${AWS::AccountId}:workgroup/${AthenaWorkgroupNameParameter}-${DeployStage}'
 
+  DashboardGetChartDataLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties: 
+      LogGroupName: !Sub "/aws/lambda/${DashboardGetChartDataFunction}"
+      RetentionInDays: !Ref RetentionTime
+
   DashboardGetMetadataFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -285,6 +333,12 @@ Resources:
       Policies:
         - S3ReadPolicy:
             BucketName: !Sub '${BucketNameParameter}-${DeployStage}'
+
+  DashboardGetMetadataLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties: 
+      LogGroupName: !Sub "/aws/lambda/${DashboardGetMetadataFunction}"
+      RetentionInDays: !Ref RetentionTime
 
   DashboardDataPackagesFunction:
     Type: AWS::Serverless::Function
@@ -337,6 +391,12 @@ Resources:
               - athena:StopQueryExecution
             Resource: !Sub 'arn:aws:athena:${AWS::Region}:${AWS::AccountId}:workgroup/${AthenaWorkgroupNameParameter}-${DeployStage}'
 
+  DashboardDataPackagesLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties: 
+      LogGroupName: !Sub "/aws/lambda/${DashboardDataPackagesFunction}"
+      RetentionInDays: !Ref RetentionTime  
+
   DashboardGetStudyPeriodsFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -371,6 +431,12 @@ Resources:
       Policies:
         - S3ReadPolicy:
             BucketName: !Sub '${BucketNameParameter}-${DeployStage}'
+
+  DashboardGetStudyPeriodsLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties: 
+      LogGroupName: !Sub "/aws/lambda/${DashboardGetStudyPeriodsFunction}"
+      RetentionInDays: !Ref RetentionTime 
 
 ### Lambda permissions
 
@@ -548,6 +614,32 @@ Resources:
 #          ResourcePath: '/*' # allows for logging on any resource
 #          HttpMethod: '*' # allows for logging on any method
 
+  DashboardApiGateway:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: !Ref DeployStage
+      Name: !Sub "CumulusAggregatorDashboardApi-${DeployStage}"
+      Auth:
+        ApiKeyRequired: true
+        UsagePlan:
+          CreateUsagePlan: PER_API
+          Description: !Sub "Usage plan for Cumulus dashboard ${DeployStage} API"
+          UsagePlanName: !Sub "CumulusAggregatorDashboardUsagePlan-${DeployStage}"
+# If your data API does not require external access, remove/comment this domain node
+      Domain:
+        DomainName: !Ref DashboardApiDomainName
+        CertificateArn: !Ref DashboardApiCertArn
+        EndpointConfiguration: EDGE
+        Route53:
+          HostedZoneId: !Ref AggregatorHostedZoneID
+
+#      MethodSettings:
+#        - LoggingLevel: INFO
+#          MetricsEnabled: True
+#          DataTraceEnabled: True
+#          ResourcePath: '/*' # allows for logging on any resource
+#          HttpMethod: '*' # allows for logging on any method
+
 ### Cloudwatch Logging infra for API gateway
 
 # The following ensures that logs generated by SiteAPIGateway will actually get
@@ -572,14 +664,6 @@ Resources:
 #        ManagedPolicyArns:
 #          - 'arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs'
 
-
-  # TODO: we will add a gateway API key to this when the dashboard is ready
-  # to handle it
-  DashboardApiGateway:
-    Type: AWS::Serverless::Api
-    Properties:
-      StageName: !Ref DeployStage
-      Name: !Sub "CumulusAggregatorDashboardApi-${DeployStage}"
 
 Outputs:
   SiteWebEndpoint:


### PR DESCRIPTION
This PR makes the following changes:
- New external URLs from route 53: `*.api.smartcumulus.org`
- Dashboard API now requires an API, which is generated on cloudformation deployment
- Added retention policies for all the lambda logging - setting it to 7 days for dev/staging, and 180 days for prod.
- Regenned OpenAPI doc for API key changes