### PR TITLE
Cleanup of get_data_packages

### DIFF
--- a/src/handlers/dashboard/get_data_packages.py
+++ b/src/handlers/dashboard/get_data_packages.py
@@ -1,6 +1,6 @@
 """ Lambda for retrieving list of available data packages
 """
-
+import ast
 import os
 
 from src.handlers.shared.decorators import generic_error_handler
@@ -17,5 +17,5 @@ def data_packages_handler(event, context):
         os.environ.get("BUCKET_NAME"),
         f"{BucketPath.CACHE.value}/{JsonFilename.DATA_PACKAGES.value}.json",
     )
-    res = http_response(200, data_packages, allow_cors=True)
+    res = http_response(200, ast.literal_eval(data_packages), allow_cors=True)
     return res

--- a/tests/dashboard/test_get_data_packages.py
+++ b/tests/dashboard/test_get_data_packages.py
@@ -11,3 +11,4 @@ def test_get_data_packages(mock_bucket):
     assert res["statusCode"] == 200
     assert DATA_PACKAGE_COUNT == 2
     assert "Access-Control-Allow-Origin" in res["headers"]
+    assert res["body"] == '["study__encounter", "other_study__encounter"]'


### PR DESCRIPTION
This removes a set of dangling quotes around the body of the `get_data_packages` lambda, which made it parse as invalid json.