### PR TITLE
Updated data package API

### DIFF
--- a/docs/dashboard-api.md
+++ b/docs/dashboard-api.md
@@ -17,10 +17,10 @@ This is the customer implementation of the Dashboard's API for receiving chart d
 which the Aggregator re-implements as a lambda building Athena queries.
 
 ### endpoint
-`/chart_data/{subscription_name}`
+`/chart_data/{data_package}`
 
 ### URL segments
-- `subscription_name` - The name of the data subscription we are querying
+- `data_package` - The name of the data package we are querying
 
 ### Query parameters
 - `column` - `string`, `required`; The name of the column we are requesting from the data table.

--- a/docs/dashboard_api.prod.yaml
+++ b/docs/dashboard_api.prod.yaml
@@ -3,72 +3,20 @@ info:
   title: "CumulusAggregatorDashboardApi"
   version: "1.0"
 servers:
-- url: "https://aggregator.smartcumulus.org/{basePath}"
+- url: "https://aggregator.smartcumulus.org/"
   variables:
     basePath:
       default: "/"
 paths:
-  /metadata/{site}/{study}/{subscription}:
-    get:
-      parameters:
-      - name: "study"
-        in: "path"
-        required: true
-        schema:
-          type: "string"
-      - name: "site"
-        in: "path"
-        required: true
-        schema:
-          type: "string"
-      - name: "subscription"
-        in: "path"
-        required: true
-        schema:
-          type: "string"
-      security:
-      - api_key: []
-    options:
-      parameters:
-      - name: "study"
-        in: "path"
-        required: true
-        schema:
-          type: "string"
-      - name: "site"
-        in: "path"
-        required: true
-        schema:
-          type: "string"
-      - name: "subscription"
-        in: "path"
-        required: true
-        schema:
-          type: "string"
-      responses:
-        "200":
-          description: "200 response"
-          headers:
-            Access-Control-Allow-Origin:
-              schema:
-                type: "string"
-            Access-Control-Allow-Methods:
-              schema:
-                type: "string"
-            Access-Control-Allow-Headers:
-              schema:
-                type: "string"
-          content: {}
-      security:
-      - api_key: []
   /data_packages:
     get:
       security:
       - api_key: []
     options:
+      summary: "CORS support"
       responses:
         "200":
-          description: "200 response"
+          description: "Default response for CORS method"
           headers:
             Access-Control-Allow-Origin:
               schema:
@@ -87,9 +35,10 @@ paths:
       security:
       - api_key: []
     options:
+      summary: "CORS support"
       responses:
         "200":
-          description: "200 response"
+          description: "Default response for CORS method"
           headers:
             Access-Control-Allow-Origin:
               schema:
@@ -114,6 +63,7 @@ paths:
       security:
       - api_key: []
     options:
+      summary: "CORS support"
       parameters:
       - name: "subscription_name"
         in: "path"
@@ -122,7 +72,7 @@ paths:
           type: "string"
       responses:
         "200":
-          description: "200 response"
+          description: "Default response for CORS method"
           headers:
             Access-Control-Allow-Origin:
               schema:
@@ -136,26 +86,37 @@ paths:
           content: {}
       security:
       - api_key: []
-  /study-periods/{site}:
+  /aggregates:
     get:
-      parameters:
-      - name: "site"
-        in: "path"
-        required: true
-        schema:
-          type: "string"
       security:
       - api_key: []
     options:
-      parameters:
-      - name: "site"
-        in: "path"
-        required: true
-        schema:
-          type: "string"
+      summary: "CORS support"
       responses:
         "200":
-          description: "200 response"
+          description: "Default response for CORS method"
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: "string"
+            Access-Control-Allow-Methods:
+              schema:
+                type: "string"
+            Access-Control-Allow-Headers:
+              schema:
+                type: "string"
+          content: {}
+      security:
+      - api_key: []
+  /last_valid:
+    get:
+      security:
+      - api_key: []
+    options:
+      summary: "CORS support"
+      responses:
+        "200":
+          description: "Default response for CORS method"
           headers:
             Access-Control-Allow-Origin:
               schema:
@@ -185,6 +146,7 @@ paths:
       security:
       - api_key: []
     options:
+      summary: "CORS support"
       parameters:
       - name: "study"
         in: "path"
@@ -198,7 +160,7 @@ paths:
           type: "string"
       responses:
         "200":
-          description: "200 response"
+          description: "Default response for CORS method"
           headers:
             Access-Control-Allow-Origin:
               schema:
@@ -212,9 +174,24 @@ paths:
           content: {}
       security:
       - api_key: []
-  /metadata/{site}:
+  /metadata/{site}/{study}/{data_package}/{version}:
     get:
       parameters:
+      - name: "data_package"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      - name: "version"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      - name: "study"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
       - name: "site"
         in: "path"
         required: true
@@ -223,7 +200,23 @@ paths:
       security:
       - api_key: []
     options:
+      summary: "CORS support"
       parameters:
+      - name: "data_package"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      - name: "version"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      - name: "study"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
       - name: "site"
         in: "path"
         required: true
@@ -231,7 +224,71 @@ paths:
           type: "string"
       responses:
         "200":
-          description: "200 response"
+          description: "Default response for CORS method"
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: "string"
+            Access-Control-Allow-Methods:
+              schema:
+                type: "string"
+            Access-Control-Allow-Headers:
+              schema:
+                type: "string"
+          content: {}
+      security:
+      - api_key: []
+  /aggregates/{study}/{data_package}/{version}/{filename}:
+    get:
+      parameters:
+      - name: "filename"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      - name: "data_package"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      - name: "version"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      - name: "study"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      security:
+      - api_key: []
+    options:
+      summary: "CORS support"
+      parameters:
+      - name: "filename"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      - name: "data_package"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      - name: "version"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      - name: "study"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      responses:
+        "200":
+          description: "Default response for CORS method"
           headers:
             Access-Control-Allow-Origin:
               schema:
@@ -261,6 +318,7 @@ paths:
       security:
       - api_key: []
     options:
+      summary: "CORS support"
       parameters:
       - name: "study"
         in: "path"
@@ -274,7 +332,203 @@ paths:
           type: "string"
       responses:
         "200":
-          description: "200 response"
+          description: "Default response for CORS method"
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: "string"
+            Access-Control-Allow-Methods:
+              schema:
+                type: "string"
+            Access-Control-Allow-Headers:
+              schema:
+                type: "string"
+          content: {}
+      security:
+      - api_key: []
+  /last_valid/{study}/{data_package}/{site}/{version}/{filename}:
+    get:
+      parameters:
+      - name: "filename"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      - name: "data_package"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      - name: "version"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      - name: "site"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      - name: "study"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      security:
+      - api_key: []
+    options:
+      summary: "CORS support"
+      parameters:
+      - name: "filename"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      - name: "data_package"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      - name: "version"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      - name: "site"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      - name: "study"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      responses:
+        "200":
+          description: "Default response for CORS method"
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: "string"
+            Access-Control-Allow-Methods:
+              schema:
+                type: "string"
+            Access-Control-Allow-Headers:
+              schema:
+                type: "string"
+          content: {}
+      security:
+      - api_key: []
+  /study-periods/{site}:
+    get:
+      parameters:
+      - name: "site"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      security:
+      - api_key: []
+    options:
+      summary: "CORS support"
+      parameters:
+      - name: "site"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      responses:
+        "200":
+          description: "Default response for CORS method"
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: "string"
+            Access-Control-Allow-Methods:
+              schema:
+                type: "string"
+            Access-Control-Allow-Headers:
+              schema:
+                type: "string"
+          content: {}
+      security:
+      - api_key: []
+  /metadata/{site}/{study}/{data_package}:
+    get:
+      parameters:
+      - name: "data_package"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      - name: "study"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      - name: "site"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      security:
+      - api_key: []
+    options:
+      summary: "CORS support"
+      parameters:
+      - name: "data_package"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      - name: "study"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      - name: "site"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      responses:
+        "200":
+          description: "Default response for CORS method"
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: "string"
+            Access-Control-Allow-Methods:
+              schema:
+                type: "string"
+            Access-Control-Allow-Headers:
+              schema:
+                type: "string"
+          content: {}
+      security:
+      - api_key: []
+  /metadata/{site}:
+    get:
+      parameters:
+      - name: "site"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      security:
+      - api_key: []
+    options:
+      summary: "CORS support"
+      parameters:
+      - name: "site"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      responses:
+        "200":
+          description: "Default response for CORS method"
           headers:
             Access-Control-Allow-Origin:
               schema:
@@ -293,9 +547,10 @@ paths:
       security:
       - api_key: []
     options:
+      summary: "CORS support"
       responses:
         "200":
-          description: "200 response"
+          description: "Default response for CORS method"
           headers:
             Access-Control-Allow-Origin:
               schema:

--- a/src/handlers/dashboard/get_chart_data.py
+++ b/src/handlers/dashboard/get_chart_data.py
@@ -37,7 +37,7 @@ def _get_table_cols(table_name: str, version: str | None = None) -> list:
 
 def _build_query(query_params: dict, filters: list, path_params: dict) -> str:
     """Creates a query from the dashboard API spec"""
-    table = path_params["subscription_name"]
+    table = path_params["data_package"]
     columns = _get_table_cols(table)
     filter_str = get_filter_string(filters)
     if filter_str != "":

--- a/src/handlers/dashboard/get_csv.py
+++ b/src/handlers/dashboard/get_csv.py
@@ -10,16 +10,16 @@ def _format_and_validate_key(
     s3_client,
     s3_bucket_name: str,
     study: str,
-    subscription: str,
+    data_package: str,
     version: str,
     filename: str,
     site: str | None = None,
 ):
     """Creates S3 key from url params"""
     if site is not None:
-        key = f"last_valid/{study}/{study}__{subscription}/{site}/{version}/{filename}"
+        key = f"last_valid/{study}/{study}__{data_package}/{site}/{version}/{filename}"
     else:
-        key = f"csv_aggregates/{study}/{study}__{subscription}/{version}/{filename}"
+        key = f"csv_aggregates/{study}/{study}__{data_package}/{version}/{filename}"
     try:
         s3_client.head_object(Bucket=s3_bucket_name, Key=key)
         return key
@@ -31,18 +31,18 @@ def _get_column_types(
     s3_client,
     s3_bucket_name: str,
     study: str,
-    subscription: str,
+    data_package: str,
     version: str,
     **kwargs,
 ) -> dict:
-    """Gets column types from the metadata store for a given subscription"""
+    """Gets column types from the metadata store for a given data_package"""
     types_metadata = functions.read_metadata(
         s3_client,
         s3_bucket_name,
         meta_type=enums.JsonFilename.COLUMN_TYPES.value,
     )
     try:
-        return types_metadata[study][subscription][version][
+        return types_metadata[study][data_package][version][
             enums.ColumnTypesKeys.COLUMNS.value
         ]
     except KeyError:
@@ -103,11 +103,11 @@ def get_csv_list_handler(event, context):
                 continue
             key_parts = obj["Key"].split("/")
             study = key_parts[1]
-            subscription = key_parts[2].split("__")[1]
+            data_package = key_parts[2].split("__")[1]
             version = key_parts[-2]
             filename = key_parts[-1]
             site = key_parts[3] if url_prefix == "last_valid" else None
-            url_parts = [url_prefix, study, subscription, version, filename]
+            url_parts = [url_prefix, study, data_package, version, filename]
             if url_prefix == "last_valid":
                 url_parts.insert(3, site)
             urls.append("/".join(url_parts))

--- a/src/handlers/dashboard/get_data_packages.py
+++ b/src/handlers/dashboard/get_data_packages.py
@@ -1,6 +1,5 @@
 """ Lambda for retrieving list of available data packages
 """
-import ast
 import os
 
 from src.handlers.shared.decorators import generic_error_handler
@@ -17,5 +16,5 @@ def data_packages_handler(event, context):
         os.environ.get("BUCKET_NAME"),
         f"{BucketPath.CACHE.value}/{JsonFilename.DATA_PACKAGES.value}.json",
     )
-    res = http_response(200, ast.literal_eval(data_packages), allow_cors=True)
+    res = http_response(200, data_packages, allow_cors=True)
     return res

--- a/src/handlers/site_upload/cache_api.py
+++ b/src/handlers/site_upload/cache_api.py
@@ -6,17 +6,12 @@ import os
 import awswrangler
 import boto3
 
-from src.handlers.shared.decorators import generic_error_handler
-from src.handlers.shared.enums import BucketPath, JsonFilename
-from src.handlers.shared.functions import http_response
+from src.handlers.shared import decorators, enums, functions
 
 
 def cache_api_data(s3_client, s3_bucket_name: str, db: str, target: str) -> None:
-    """Performs caching of API data
-
-    In the future, this will be used for more than one type of data caching.
-    """
-    if target == JsonFilename.DATA_PACKAGES.value:
+    """Performs caching of API data"""
+    if target == enums.JsonFilename.DATA_PACKAGES.value:
         df = awswrangler.athena.read_sql_query(
             (
                 f"SELECT table_name FROM information_schema.tables "
@@ -28,15 +23,34 @@ def cache_api_data(s3_client, s3_bucket_name: str, db: str, target: str) -> None
         )
     else:
         raise KeyError("Invalid API caching target")
-    data_packages = df.iloc[:, 0].to_json(orient="values")
+    data_packages = df[df["table_name"].str.contains("__")].iloc[:, 0]
+    column_types = functions.get_s3_json_as_dict(
+        os.environ.get("BUCKET_NAME"),
+        f"{enums.BucketPath.META.value}/{enums.JsonFilename.COLUMN_TYPES.value}.json",
+    )
+    dp_details = []
+    for dp in list(data_packages):
+        dp_detail = {
+            "id": dp,
+            "study": dp.split("__", 1)[0],
+            "name": dp.split("__", 1)[1],
+        }
+        try:
+            versions = column_types[dp_detail["study"]][dp_detail["name"]]
+            for version in versions:
+                dp_details.append(
+                    {**dp_detail, **versions[version], "version": version}
+                )
+        except KeyError:
+            continue
     s3_client.put_object(
         Bucket=s3_bucket_name,
-        Key=f"{BucketPath.CACHE.value}/{JsonFilename.DATA_PACKAGES.value}.json",
-        Body=json.dumps(data_packages),
+        Key=f"{enums.BucketPath.CACHE.value}/{enums.JsonFilename.DATA_PACKAGES.value}.json",
+        Body=json.dumps(dp_details),
     )
 
 
-@generic_error_handler(msg="Error caching API responses")
+@decorators.generic_error_handler(msg="Error caching API responses")
 def cache_api_handler(event, context):
     """manages event from SNS, executes queries and stashes cache in S#"""
     del context
@@ -45,5 +59,5 @@ def cache_api_handler(event, context):
     db = os.environ.get("GLUE_DB_NAME")
     target = event["Records"][0]["Sns"]["Subject"]
     cache_api_data(s3_client, s3_bucket_name, db, target)
-    res = http_response(200, "Study period update successful")
+    res = functions.http_response(200, "Study period update successful")
     return res

--- a/src/handlers/site_upload/process_upload.py
+++ b/src/handlers/site_upload/process_upload.py
@@ -1,9 +1,14 @@
 """ Lambda for moving data to processing locations """
+import logging
 import os
 
 import boto3
 
 from src.handlers.shared import decorators, enums, functions
+
+log_level = os.environ.get("LAMBDA_LOG_LEVEL", "INFO")
+logger = logging.getLogger()
+logger.setLevel(log_level)
 
 
 class UnexpectedFileTypeError(Exception):
@@ -15,19 +20,15 @@ def process_upload(s3_client, sns_client, s3_bucket_name: str, s3_key: str) -> N
     last_uploaded_date = s3_client.head_object(Bucket=s3_bucket_name, Key=s3_key)[
         "LastModified"
     ]
+
+    logger.info(f"Proccessing upload at {s3_key}")
     metadata = functions.read_metadata(s3_client, s3_bucket_name)
     path_params = s3_key.split("/")
     study = path_params[1]
     data_package = path_params[2]
     site = path_params[3]
     version = path_params[4]
-    # If someone runs an upload on the template study, we'll just move it
-    # to archive - we don't care about metadata for this, but can look there to
-    # verify transmission if it's a connectivity test
-    if study == "template":
-        new_key = f"{enums.BucketPath.ARCHIVE.value}/{s3_key.split('/', 1)[-1]}"
-        functions.move_s3_file(s3_client, s3_bucket_name, s3_key, new_key)
-    elif s3_key.endswith(".parquet"):
+    if s3_key.endswith(".parquet"):
         if "__meta_" in s3_key or "/discovery__" in s3_key:
             new_key = f"{enums.BucketPath.STUDY_META.value}/{s3_key.split('/', 1)[-1]}"
             topic_sns_arn = os.environ.get("TOPIC_PROCESS_STUDY_META_ARN")

--- a/template.yaml
+++ b/template.yaml
@@ -48,6 +48,22 @@ Parameters:
     Type: String
   RetentionTime:
     Type: Number
+  LogLevel:
+    Type: String
+    AllowedValues:
+      - TRACE
+      - DEBUG
+      - INFO
+      - WARN
+      - ERROR
+      - FATAL
+    Default: INFO
+  LogFormat:
+    Type: String
+    AllowedValues:
+      - Text
+      - JSON
+    Default: JSON
 
 
 Resources:
@@ -61,7 +77,11 @@ Resources:
     Properties:
       FunctionName: !Sub 'CumulusAggFetchAuthorizer-${DeployStage}'
       Handler: src/handlers/site_upload/api_gateway_authorizer.lambda_handler
-      Runtime: python3.10
+      Runtime: "python3.11"
+      LoggingConfig:
+        ApplicationLogLevel: !Ref LogLevel
+        LogFormat: !Ref LogFormat
+        LogGroup: !Sub "/aws/lambda/CumulusAggFetchAuthorizerFunction-${DeployStage}"
       MemorySize: 128
       Timeout: 100
       Description: Validates credentials before providing signed urls
@@ -91,7 +111,11 @@ Resources:
     Properties:
       FunctionName: !Sub 'CumulusAggFetchUploadUrl-${DeployStage}'
       Handler: src/handlers/site_upload/fetch_upload_url.upload_url_handler
-      Runtime: python3.10
+      Runtime: "python3.11"
+      LoggingConfig:
+        ApplicationLogLevel: !Ref LogLevel
+        LogFormat: !Ref LogFormat
+        LogGroup: !Sub "/aws/lambda/CumulusAggFetchUploadUrlFunction-${DeployStage}"
       MemorySize: 128
       Timeout: 100
       Description: Generates a presigned URL for uploading files to S3
@@ -128,7 +152,11 @@ Resources:
     Properties:
       FunctionName: !Sub 'CumulusAggProcessUpload-${DeployStage}'
       Handler: src/handlers/site_upload/process_upload.process_upload_handler
-      Runtime: python3.10
+      Runtime: "python3.11"
+      LoggingConfig:
+        ApplicationLogLevel: !Ref LogLevel
+        LogFormat: !Ref LogFormat
+        LogGroup: !Sub "/aws/lambda/CumulusAggProcessUploadFunction-${DeployStage}"
       MemorySize: 128
       Timeout: 800
       Description: Handles initial relocation of upload data
@@ -162,9 +190,13 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       FunctionName: !Sub 'CumulusAggPowersetMerge-${DeployStage}'
-      Layers: [arn:aws:lambda:us-east-1:336392948345:layer:AWSSDKPandas-Python39:1]
+      Layers: [arn:aws:lambda:us-east-1:336392948345:layer:AWSSDKPandas-Python311:17]
       Handler: src/handlers/site_upload/powerset_merge.powerset_merge_handler
-      Runtime: python3.10
+      Runtime: "python3.11"
+      LoggingConfig:
+        ApplicationLogLevel: !Ref LogLevel
+        LogFormat: !Ref LogFormat
+        LogGroup: !Sub "/aws/lambda/CumulusAggPowersetMergeFunction-${DeployStage}"
       MemorySize: 8192
       Timeout: 800
       Description: Merges and aggregates powerset count data
@@ -200,9 +232,13 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       FunctionName: !Sub 'CumulusAggStudyPeriod-${DeployStage}'
-      Layers: [arn:aws:lambda:us-east-1:336392948345:layer:AWSSDKPandas-Python39:1]
+      Layers: [arn:aws:lambda:us-east-1:336392948345:layer:AWSSDKPandas-Python311:17]
       Handler: src/handlers/site_upload/study_period.study_period_handler
-      Runtime: python3.10
+      Runtime: "python3.11"
+      LoggingConfig:
+        ApplicationLogLevel: !Ref LogLevel
+        LogFormat: !Ref LogFormat
+        LogGroup: !Sub "/aws/lambda/CumulusAggStudyPeriod-${DeployStage}"
       MemorySize: 512
       Timeout: 800
       Description: Handles metadata outside of upload/processing for studies
@@ -235,9 +271,13 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       FunctionName: !Sub 'CumulusAggCacheAPI-${DeployStage}'
-      Layers: [arn:aws:lambda:us-east-1:336392948345:layer:AWSSDKPandas-Python39:1]
+      Layers: [arn:aws:lambda:us-east-1:336392948345:layer:AWSSDKPandas-Python311:17]
       Handler: src/handlers/site_upload/cache_api.cache_api_handler
-      Runtime: python3.10
+      Runtime: "python3.11"
+      LoggingConfig:
+        ApplicationLogLevel: !Ref LogLevel
+        LogFormat: !Ref LogFormat
+        LogGroup: !Sub "/aws/lambda/CumulusAggCacheAPI-${DeployStage}"
       MemorySize: 512
       Timeout: 800
       Description: Caches selected database queries to S3
@@ -290,9 +330,13 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       FunctionName: !Sub 'CumulusAggDashboardGetChartData-${DeployStage}'
-      Layers: [arn:aws:lambda:us-east-1:336392948345:layer:AWSSDKPandas-Python39:1]
+      Layers: [arn:aws:lambda:us-east-1:336392948345:layer:AWSSDKPandas-Python311:17]
       Handler: src/handlers/dashboard/get_chart_data.chart_data_handler
-      Runtime: python3.10
+      Runtime: "python3.11"
+      LoggingConfig:
+        ApplicationLogLevel: !Ref LogLevel
+        LogFormat: !Ref LogFormat
+        LogGroup: !Sub "/aws/lambda/CumulusAggDashboardGetChartDataFunction-${DeployStage}"
       MemorySize: 2048
       Timeout: 100
       Description: Retrieve data for chart display in Cumulus Dashboard
@@ -346,7 +390,11 @@ Resources:
     Properties:
       FunctionName: !Sub 'CumulusAggDashboardGetCsv-${DeployStage}'
       Handler: src/handlers/dashboard/get_csv.get_csv_handler
-      Runtime: python3.10
+      Runtime: "python3.11"
+      LoggingConfig:
+        ApplicationLogLevel: !Ref LogLevel
+        LogFormat: !Ref LogFormat
+        LogGroup: !Sub "/aws/lambda/CumulusAggDashboardGetCsvFunction-${DeployStage}"
       MemorySize: 128
       Timeout: 100
       Description: Redirect to presigned URL for download of aggregate CSVs
@@ -358,13 +406,13 @@ Resources:
           Type: Api
           Properties:
             RestApiId: !Ref DashboardApiGateway
-            Path: /aggregates/{study}/{subscription}/{version}/{filename}
+            Path: /aggregates/{study}/{data_package}/{version}/{filename}
             Method: GET
         GetLastValidAPI:
           Type: Api
           Properties:
             RestApiId: !Ref DashboardApiGateway
-            Path: /last_valid/{study}/{subscription}/{site}/{version}/{filename}
+            Path: /last_valid/{study}/{data_package}/{site}/{version}/{filename}
             Method: GET
       Policies:
         - S3ReadPolicy:
@@ -388,7 +436,11 @@ Resources:
     Properties:
       FunctionName: !Sub 'CumulusAggDashboardGetCsvList-${DeployStage}'
       Handler: src/handlers/dashboard/get_csv.get_csv_list_handler
-      Runtime: python3.10
+      Runtime: "python3.11"
+      LoggingConfig:
+        ApplicationLogLevel: !Ref LogLevel
+        LogFormat: !Ref LogFormat
+        LogGroup: !Sub "/aws/lambda/CumulusAggDashboardGetCsvList-${DeployStage}"
       MemorySize: 128
       Timeout: 100
       Description: List all available csvs from the aggregator
@@ -431,7 +483,11 @@ Resources:
     Properties:
       FunctionName: !Sub 'CumulusAggDashboardGetMetadata-${DeployStage}'
       Handler: src/handlers/dashboard/get_metadata.metadata_handler
-      Runtime: python3.10
+      Runtime: "python3.11"
+      LoggingConfig:
+        ApplicationLogLevel: !Ref LogLevel
+        LogFormat: !Ref LogFormat
+        LogGroup: !Sub "/aws/lambda/CumulusAggDashboardGetMetadata-${DeployStage}"
       MemorySize: 128
       Timeout: 100
       Description: Retrieve data about site uploads
@@ -461,13 +517,13 @@ Resources:
           Type: Api
           Properties:
             RestApiId: !Ref DashboardApiGateway
-            Path: /metadata/{site}/{study}/{subscription}
+            Path: /metadata/{site}/{study}/{data_package}
             Method: GET
         GetMetadataSiteStudySubscriptionVersionAPI:
           Type: Api
           Properties:
             RestApiId: !Ref DashboardApiGateway
-            Path: /metadata/{site}/{study}/{subscription}/{version}
+            Path: /metadata/{site}/{study}/{data_package}/{version}
             Method: GET
       Policies:
         - S3ReadPolicy:
@@ -490,9 +546,13 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       FunctionName: !Sub 'CumulusAggDashboardDataPackages-${DeployStage}'
-      Layers: [arn:aws:lambda:us-east-1:336392948345:layer:AWSSDKPandas-Python39:1]
+      Layers: [arn:aws:lambda:us-east-1:336392948345:layer:AWSSDKPandas-Python311:17]
       Handler: src/handlers/dashboard/get_data_packages.data_packages_handler
-      Runtime: python3.10
+      Runtime: "python3.11"
+      LoggingConfig:
+        ApplicationLogLevel: !Ref LogLevel
+        LogFormat: !Ref LogFormat
+        LogGroup: !Sub "/aws/lambda/CumulusAggDashboardDataPackages-${DeployStage}"
       MemorySize: 512
       Timeout: 100
       Description: Retrieve data for chart display in Cumulus Dashboard
@@ -555,7 +615,11 @@ Resources:
     Properties:
       FunctionName: !Sub 'CumulusAggDashboardStudyPeriods-${DeployStage}'
       Handler: src/handlers/dashboard/get_study_periods.study_periods_handler
-      Runtime: python3.10
+      Runtime: "python3.11"
+      LoggingConfig:
+        ApplicationLogLevel: !Ref LogLevel
+        LogFormat: !Ref LogFormat
+        LogGroup: !Sub "/aws/lambda/CumulusAggDashboardStudyPeriods-${DeployStage}"
       MemorySize: 128
       Timeout: 100
       Description: Retrieve data about the study period

--- a/tests/dashboard/test_get_chart_data.py
+++ b/tests/dashboard/test_get_chart_data.py
@@ -35,7 +35,7 @@ def mock_data_frame(filter_param):
         (
             {"column": "gender"},
             [],
-            {"subscription_name": "test_study"},
+            {"data_package": "test_study"},
             f'SELECT gender, sum(cnt) as cnt FROM "{TEST_GLUE_DB}"."test_study" '
             "WHERE COALESCE (race) IS NOT Null AND gender IS NOT Null  "
             "GROUP BY gender",
@@ -43,7 +43,7 @@ def mock_data_frame(filter_param):
         (
             {"column": "gender", "stratifier": "race"},
             [],
-            {"subscription_name": "test_study"},
+            {"data_package": "test_study"},
             f'SELECT race, gender, sum(cnt) as cnt FROM "{TEST_GLUE_DB}"."test_study" '
             "WHERE gender IS NOT Null  "
             "GROUP BY race, gender",
@@ -51,7 +51,7 @@ def mock_data_frame(filter_param):
         (
             {"column": "gender"},
             ["gender:strEq:female"],
-            {"subscription_name": "test_study"},
+            {"data_package": "test_study"},
             f'SELECT gender, sum(cnt) as cnt FROM "{TEST_GLUE_DB}"."test_study" '
             "WHERE COALESCE (race) IS NOT Null AND gender IS NOT Null "
             "AND gender LIKE 'female' "
@@ -60,7 +60,7 @@ def mock_data_frame(filter_param):
         (
             {"column": "gender", "stratifier": "race"},
             ["gender:strEq:female"],
-            {"subscription_name": "test_study"},
+            {"data_package": "test_study"},
             f'SELECT race, gender, sum(cnt) as cnt FROM "{TEST_GLUE_DB}"."test_study" '
             "WHERE gender IS NOT Null "
             "AND gender LIKE 'female' "

--- a/tests/dashboard/test_get_csv.py
+++ b/tests/dashboard/test_get_csv.py
@@ -13,9 +13,9 @@ from tests import mock_utils
 # data matching these params is created via conftest
 site = mock_utils.EXISTING_SITE
 study = mock_utils.EXISTING_STUDY
-subscription = mock_utils.EXISTING_DATA_P
+data_package = mock_utils.EXISTING_DATA_P
 version = mock_utils.EXISTING_VERSION
-filename = filename = f"{study}__{subscription}__aggregate.csv"
+filename = filename = f"{study}__{data_package}__aggregate.csv"
 
 
 def _mock_last_valid():
@@ -25,7 +25,7 @@ def _mock_last_valid():
         "./tests/test_data/count_synthea_patient_agg.csv",
         bucket,
         f"{enums.BucketPath.LAST_VALID.value}/{study}/"
-        f"{study}__{subscription}/{site}/{version}/{filename}",
+        f"{study}__{data_package}/{site}/{version}/{filename}",
     )
 
 
@@ -36,7 +36,7 @@ def _mock_last_valid():
             {
                 "site": None,
                 "study": study,
-                "subscription": subscription,
+                "data_package": data_package,
                 "version": version,
                 "filename": filename,
             },
@@ -47,7 +47,7 @@ def _mock_last_valid():
             {
                 "site": site,
                 "study": study,
-                "subscription": subscription,
+                "data_package": data_package,
                 "version": version,
                 "filename": filename,
             },
@@ -57,7 +57,7 @@ def _mock_last_valid():
         (
             {
                 "study": study,
-                "subscription": subscription,
+                "data_package": data_package,
                 "version": version,
                 "filename": filename,
             },
@@ -68,7 +68,7 @@ def _mock_last_valid():
             {
                 "site": site,
                 "study": study,
-                "subscription": subscription,
+                "data_package": data_package,
                 "version": version,
                 "filename": "foo",
             },
@@ -79,7 +79,7 @@ def _mock_last_valid():
             {
                 "site": None,
                 "study": None,
-                "subscription": None,
+                "data_package": None,
                 "version": None,
                 "filename": None,
             },
@@ -99,12 +99,12 @@ def test_get_csv(mock_bucket, params, status, expected):
         if "site" not in params or params["site"] is None:
             url = (
                 "https://cumulus-aggregator-site-counts-test.s3.amazonaws.com/csv_aggregates/"
-                f"{study}/{study}__{subscription}/{version}/{filename}"
+                f"{study}/{study}__{data_package}/{version}/{filename}"
             )
         else:
             url = (
                 "https://cumulus-aggregator-site-counts-test.s3.amazonaws.com/last_valid/"
-                f"{study}/{study}__{subscription}/{site}/{version}/{filename}"
+                f"{study}/{study}__{data_package}/{site}/{version}/{filename}"
             )
         assert (
             res["headers"]["x-column-types"] == "integer,string,integer,string,string"

--- a/tests/dashboard/test_get_data_packages.py
+++ b/tests/dashboard/test_get_data_packages.py
@@ -1,3 +1,4 @@
+import json
 import os
 from unittest import mock
 
@@ -11,4 +12,33 @@ def test_get_data_packages(mock_bucket):
     assert res["statusCode"] == 200
     assert DATA_PACKAGE_COUNT == 2
     assert "Access-Control-Allow-Origin" in res["headers"]
-    assert res["body"] == '["study__encounter", "other_study__encounter"]'
+    assert json.loads(res["body"]) == {
+        "study_valid": {
+            "table": {
+                "001": {
+                    "column_types_format_version": "1",
+                    "columns": {
+                        "cnt": "integer",
+                        "class_display": "string",
+                        "servicetype_display": "string",
+                        "period_start_month": "month",
+                        "site": "string",
+                    },
+                    "last_data_update": "2024-09-25T20:12:45.193296+00:00",
+                    "total": 31669,
+                },
+                "002": {
+                    "column_types_format_version": "1",
+                    "columns": {
+                        "cnt": "integer",
+                        "enc_class_display": "string",
+                        "enc_service_display": "string",
+                        "start_month": "month",
+                        "site": "string",
+                    },
+                    "last_data_update": "2024-10-01T18:12:13.463978+00:00",
+                    "total": 7695176,
+                },
+            }
+        }
+    }

--- a/tests/site_upload/test_cache_api.py
+++ b/tests/site_upload/test_cache_api.py
@@ -9,7 +9,7 @@ from tests.mock_utils import MOCK_ENV, get_mock_data_packages_cache
 
 
 def mock_data_packages(*args, **kwargs):
-    return pandas.DataFrame(get_mock_data_packages_cache())
+    return pandas.DataFrame(get_mock_data_packages_cache(), columns=["table_name"])
 
 
 @mock.patch.dict(os.environ, MOCK_ENV)

--- a/tests/test_data/data_packages_cache.json
+++ b/tests/test_data/data_packages_cache.json
@@ -1,1 +1,30 @@
-"[\"study__encounter\",\"other_study__encounter\"]"
+{
+    "study_valid": {
+        "table": {
+            "001": {
+                "column_types_format_version": "1",
+                "columns": {
+                    "cnt": "integer",
+                    "class_display": "string",
+                    "servicetype_display": "string",
+                    "period_start_month": "month",
+                    "site": "string"
+                },
+                "last_data_update": "2024-09-25T20:12:45.193296+00:00",
+                "total": 31669
+            },
+            "002": {
+                "column_types_format_version": "1",
+                "columns": {
+                    "cnt": "integer",
+                    "enc_class_display": "string",
+                    "enc_service_display": "string",
+                    "start_month": "month",
+                    "site": "string"
+                },
+                "last_data_update": "2024-10-01T18:12:13.463978+00:00",
+                "total": 7695176
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR makes the following changes:

- Changes 'subscription' to 'data_package' in dashboard API to line up with nomenclature reorg
- Changes data_packages/ output format
  - Now proper json
  - Uses metadata to express more information about the contents of the data package
- Starts a process of improving logging by specifying JSON output and using the logger to write basic status messages