### PR TITLE
Added filtering to data_packages

### DIFF
--- a/docs/dashboard_api.prod.yaml
+++ b/docs/dashboard_api.prod.yaml
@@ -10,6 +10,11 @@ servers:
 paths:
   /data_packages:
     get:
+      parameters:
+      - name: "name"
+        in: "query"
+        schema:
+          type: "string"
       security:
       - api_key: []
     options:
@@ -488,6 +493,39 @@ paths:
         schema:
           type: "string"
       - name: "site"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      responses:
+        "200":
+          description: "Default response for CORS method"
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: "string"
+            Access-Control-Allow-Methods:
+              schema:
+                type: "string"
+            Access-Control-Allow-Headers:
+              schema:
+                type: "string"
+          content: {}
+      security:
+      - api_key: []
+  /data_packages/{id}:
+    get:
+      parameters:
+      - name: "id"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      security:
+      - api_key: []
+    options:
+      parameters:
+      - name: "id"
         in: "path"
         required: true
         schema:

--- a/src/handlers/dashboard/get_data_packages.py
+++ b/src/handlers/dashboard/get_data_packages.py
@@ -10,11 +10,28 @@ from src.handlers.shared.functions import get_s3_json_as_dict, http_response
 @generic_error_handler(msg="Error retrieving data packages")
 def data_packages_handler(event, context):
     """Retrieves list of data packages from S3."""
-    del event
     del context
+    status = 200
     data_packages = get_s3_json_as_dict(
         os.environ.get("BUCKET_NAME"),
         f"{BucketPath.CACHE.value}/{JsonFilename.DATA_PACKAGES.value}.json",
     )
-    res = http_response(200, data_packages, allow_cors=True)
+    payload = data_packages
+    if event.get("queryStringParameters"):
+        filtered_packages = []
+        for package in data_packages:
+            if package["name"] == event["queryStringParameters"]["name"]:
+                filtered_packages.append(package)
+        payload = filtered_packages
+    elif event.get("pathParameters"):
+        found = None
+        for package in data_packages:
+            if event["pathParameters"]["id"] == package["id"]:
+                found = package
+        if found:
+            payload = found
+        else:
+            status = 404
+            payload = None
+    res = http_response(status, payload, allow_cors=True)
     return res

--- a/template.yaml
+++ b/template.yaml
@@ -568,6 +568,15 @@ Resources:
             RestApiId: !Ref DashboardApiGateway
             Path: /data_packages
             Method: GET
+            RequestParameters: 
+              - method.request.querystring.name:
+                  Required: false
+        DataPackagesIDAPI:
+          Type: Api
+          Properties:
+            RestApiId: !Ref DashboardApiGateway
+            Path: /data_packages/{id}
+            Method: GET
       # TODO: it :should: be possible to move these policies to a central role/policy
       # set that can be referenced in multiple places; see
       # https://stackoverflow.com/questions/64523817/aws-sam-multiple-functions-with-same-inline-policy

--- a/tests/dashboard/test_get_data_packages.py
+++ b/tests/dashboard/test_get_data_packages.py
@@ -1,5 +1,6 @@
 import json
 import os
+import pathlib
 from unittest import mock
 
 from src.handlers.dashboard.get_data_packages import data_packages_handler
@@ -8,37 +9,21 @@ from tests.mock_utils import DATA_PACKAGE_COUNT, MOCK_ENV
 
 @mock.patch.dict(os.environ, MOCK_ENV)
 def test_get_data_packages(mock_bucket):
+    with open(pathlib.Path(__file__).parent.parent / "./test_data/data_packages_cache.json") as f:
+        data = json.load(f)
     res = data_packages_handler({}, {})
     assert res["statusCode"] == 200
-    assert DATA_PACKAGE_COUNT == 2
+    assert DATA_PACKAGE_COUNT == len(data)
     assert "Access-Control-Allow-Origin" in res["headers"]
-    assert json.loads(res["body"]) == {
-        "study_valid": {
-            "table": {
-                "001": {
-                    "column_types_format_version": "1",
-                    "columns": {
-                        "cnt": "integer",
-                        "class_display": "string",
-                        "servicetype_display": "string",
-                        "period_start_month": "month",
-                        "site": "string",
-                    },
-                    "last_data_update": "2024-09-25T20:12:45.193296+00:00",
-                    "total": 31669,
-                },
-                "002": {
-                    "column_types_format_version": "1",
-                    "columns": {
-                        "cnt": "integer",
-                        "enc_class_display": "string",
-                        "enc_service_display": "string",
-                        "start_month": "month",
-                        "site": "string",
-                    },
-                    "last_data_update": "2024-10-01T18:12:13.463978+00:00",
-                    "total": 7695176,
-                },
-            }
-        }
-    }
+    assert json.loads(res["body"]) == data
+    res = data_packages_handler({"queryStringParameters": {"name": "encounter"}}, {})
+    data = json.loads(res["body"])
+    assert res["statusCode"] == 200
+    assert 2 == len(json.loads(res["body"]))
+    for item in data:
+        assert item["name"] == "encounter"
+    res = data_packages_handler({"pathParameters": {"id": "other_study__document__100"}}, {})
+    data = json.loads(res["body"])
+    assert res["statusCode"] == 200
+    assert 9 == len(data)
+    assert data["id"] == "other_study__document__100"

--- a/tests/dashboard/test_get_data_packages.py
+++ b/tests/dashboard/test_get_data_packages.py
@@ -27,3 +27,6 @@ def test_get_data_packages(mock_bucket):
     assert res["statusCode"] == 200
     assert 9 == len(data)
     assert data["id"] == "other_study__document__100"
+    res = data_packages_handler({"pathParameters": {"id": "not_an_id"}}, {})
+    data = json.loads(res["body"])
+    assert res["statusCode"] == 404

--- a/tests/mock_utils.py
+++ b/tests/mock_utils.py
@@ -7,7 +7,7 @@ TEST_PROCESS_COUNTS_ARN = "arn:aws:sns:us-east-1:123456789012:test-counts"
 TEST_PROCESS_STUDY_META_ARN = "arn:aws:sns:us-east-1:123456789012:test-meta"
 TEST_CACHE_API_ARN = "arn:aws:sns:us-east-1:123456789012:test-cache"
 ITEM_COUNT = 10
-DATA_PACKAGE_COUNT = 2
+DATA_PACKAGE_COUNT = 3
 
 EXISTING_SITE = "princeton_plainsboro_teaching_hospital"
 NEW_SITE = "chicago_hope"

--- a/tests/test_data/data_packages_cache.json
+++ b/tests/test_data/data_packages_cache.json
@@ -1,30 +1,53 @@
-{
-    "study_valid": {
-        "table": {
-            "001": {
-                "column_types_format_version": "1",
-                "columns": {
-                    "cnt": "integer",
-                    "class_display": "string",
-                    "servicetype_display": "string",
-                    "period_start_month": "month",
-                    "site": "string"
-                },
-                "last_data_update": "2024-09-25T20:12:45.193296+00:00",
-                "total": 31669
-            },
-            "002": {
-                "column_types_format_version": "1",
-                "columns": {
-                    "cnt": "integer",
-                    "enc_class_display": "string",
-                    "enc_service_display": "string",
-                    "start_month": "month",
-                    "site": "string"
-                },
-                "last_data_update": "2024-10-01T18:12:13.463978+00:00",
-                "total": 7695176
-            }
-        }
+[
+    {
+        "study": "study",
+        "name": "encounter",
+        "column_types_format_version": "100",
+        "columns": {
+            "cnt": "integer",
+            "class_display": "string",
+            "servicetype_display": "string",
+            "period_start_month": "month",
+            "site": "string"
+        },
+        "last_data_update": "2024-09-25T20:12:45.193296+00:00",
+        "s3_path":"aggregates/study/study__encounter/100/study__encounter__aggregate.csv",
+        "total": 31669,
+        "version": "100",
+        "id": "study__encounter__100"
+    },
+    {
+        "study": "study",
+        "name": "encounter",
+        "column_types_format_version": "099",
+        "columns": {
+            "cnt": "integer",
+            "class_display": "string",
+            "servicetype_display": "string",
+            "period_start_month": "month",
+            "site": "string"
+        },
+        "last_data_update": "2024-09-25T20:12:45.193296+00:00",
+        "s3_path":"aggregates/study/study__encounter/099/study__encounter__aggregate.csv",
+        "total": 31669,
+        "version": "099",
+        "id": "study__encounter__099"
+    },
+    {
+        "study": "other_study",
+        "name": "document",
+        "column_types_format_version": "2",
+        "columns": {
+            "cnt": "integer",
+            "enc_class_display": "string",
+            "enc_service_display": "string",
+            "start_month": "month",
+            "site": "string"
+        },
+        "last_data_update": "2024-10-01T18:12:13.463978+00:00",
+        "s3_path":"aggregates/other_study/other_study__document/002/other_study__document__aggregate.csv",
+        "total": 7695176,
+        "version": "100",
+        "id": "other_study__document__100"
     }
-}
+]


### PR DESCRIPTION
This allows the results of the data package to be filter by either a query param (of name), or by explicit id field.

It also updates the test data to match the v2 format.