### PR TITLE
Updated chart data, S3 aggregate parquet moved

### DIFF
--- a/docs/dashboard_api.prod.yaml
+++ b/docs/dashboard_api.prod.yaml
@@ -57,40 +57,6 @@ paths:
           content: {}
       security:
       - api_key: []
-  /chart-data/{subscription_name}:
-    get:
-      parameters:
-      - name: "subscription_name"
-        in: "path"
-        required: true
-        schema:
-          type: "string"
-      security:
-      - api_key: []
-    options:
-      summary: "CORS support"
-      parameters:
-      - name: "subscription_name"
-        in: "path"
-        required: true
-        schema:
-          type: "string"
-      responses:
-        "200":
-          description: "Default response for CORS method"
-          headers:
-            Access-Control-Allow-Origin:
-              schema:
-                type: "string"
-            Access-Control-Allow-Methods:
-              schema:
-                type: "string"
-            Access-Control-Allow-Headers:
-              schema:
-                type: "string"
-          content: {}
-      security:
-      - api_key: []
   /aggregates:
     get:
       security:
@@ -351,6 +317,48 @@ paths:
           content: {}
       security:
       - api_key: []
+  /data_packages/{data_package_id}/chart:
+    get:
+      parameters:
+      - name: "data_package_id"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      - name: "column"
+        in: "query"
+        required: true
+        schema:
+          type: "string"
+      - name: "filters"
+        in: "query"
+        schema:
+          type: "string"
+      security:
+      - api_key: []
+    options:
+      parameters:
+      - name: "data_package_id"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      responses:
+        "200":
+          description: "Default response for CORS method"
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: "string"
+            Access-Control-Allow-Methods:
+              schema:
+                type: "string"
+            Access-Control-Allow-Headers:
+              schema:
+                type: "string"
+          content: {}
+      security:
+      - api_key: []
   /last_valid/{study}/{data_package}/{site}/{version}/{filename}:
     get:
       parameters:
@@ -513,39 +521,6 @@ paths:
           content: {}
       security:
       - api_key: []
-  /data_packages/{id}:
-    get:
-      parameters:
-      - name: "id"
-        in: "path"
-        required: true
-        schema:
-          type: "string"
-      security:
-      - api_key: []
-    options:
-      parameters:
-      - name: "id"
-        in: "path"
-        required: true
-        schema:
-          type: "string"
-      responses:
-        "200":
-          description: "Default response for CORS method"
-          headers:
-            Access-Control-Allow-Origin:
-              schema:
-                type: "string"
-            Access-Control-Allow-Methods:
-              schema:
-                type: "string"
-            Access-Control-Allow-Headers:
-              schema:
-                type: "string"
-          content: {}
-      security:
-      - api_key: []
   /metadata/{site}:
     get:
       parameters:
@@ -586,6 +561,39 @@ paths:
       - api_key: []
     options:
       summary: "CORS support"
+      responses:
+        "200":
+          description: "Default response for CORS method"
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: "string"
+            Access-Control-Allow-Methods:
+              schema:
+                type: "string"
+            Access-Control-Allow-Headers:
+              schema:
+                type: "string"
+          content: {}
+      security:
+      - api_key: []
+  /data_packages/{data_package_id}:
+    get:
+      parameters:
+      - name: "data_package_id"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      security:
+      - api_key: []
+    options:
+      parameters:
+      - name: "data_package_id"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
       responses:
         "200":
           description: "Default response for CORS method"

--- a/docs/dashboard_api.prod.yaml
+++ b/docs/dashboard_api.prod.yaml
@@ -8,33 +8,6 @@ servers:
     basePath:
       default: "/"
 paths:
-  /data_packages:
-    get:
-      parameters:
-      - name: "name"
-        in: "query"
-        schema:
-          type: "string"
-      security:
-      - api_key: []
-    options:
-      summary: "CORS support"
-      responses:
-        "200":
-          description: "Default response for CORS method"
-          headers:
-            Access-Control-Allow-Origin:
-              schema:
-                type: "string"
-            Access-Control-Allow-Methods:
-              schema:
-                type: "string"
-            Access-Control-Allow-Headers:
-              schema:
-                type: "string"
-          content: {}
-      security:
-      - api_key: []
   /metadata:
     get:
       security:
@@ -57,15 +30,14 @@ paths:
           content: {}
       security:
       - api_key: []
-  /aggregates:
+  /last-valid:
     get:
       security:
       - api_key: []
     options:
-      summary: "CORS support"
       responses:
         "200":
-          description: "Default response for CORS method"
+          description: "200 response"
           headers:
             Access-Control-Allow-Origin:
               schema:
@@ -79,7 +51,49 @@ paths:
           content: {}
       security:
       - api_key: []
-  /last_valid:
+  /data-packages/{data_package_id}/chart:
+    get:
+      parameters:
+      - name: "data_package_id"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      - name: "column"
+        in: "query"
+        required: true
+        schema:
+          type: "string"
+      - name: "filters"
+        in: "query"
+        schema:
+          type: "string"
+      security:
+      - api_key: []
+    options:
+      parameters:
+      - name: "data_package_id"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      responses:
+        "200":
+          description: "200 response"
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: "string"
+            Access-Control-Allow-Methods:
+              schema:
+                type: "string"
+            Access-Control-Allow-Headers:
+              schema:
+                type: "string"
+          content: {}
+      security:
+      - api_key: []
+  /aggregates:
     get:
       security:
       - api_key: []
@@ -317,35 +331,19 @@ paths:
           content: {}
       security:
       - api_key: []
-  /data_packages/{data_package_id}/chart:
+  /data-packages:
     get:
       parameters:
-      - name: "data_package_id"
-        in: "path"
-        required: true
-        schema:
-          type: "string"
-      - name: "column"
-        in: "query"
-        required: true
-        schema:
-          type: "string"
-      - name: "filters"
+      - name: "name"
         in: "query"
         schema:
           type: "string"
       security:
       - api_key: []
     options:
-      parameters:
-      - name: "data_package_id"
-        in: "path"
-        required: true
-        schema:
-          type: "string"
       responses:
         "200":
-          description: "Default response for CORS method"
+          description: "200 response"
           headers:
             Access-Control-Allow-Origin:
               schema:
@@ -359,7 +357,7 @@ paths:
           content: {}
       security:
       - api_key: []
-  /last_valid/{study}/{data_package}/{site}/{version}/{filename}:
+  /last-valid/{study}/{data_package}/{site}/{version}/{filename}:
     get:
       parameters:
       - name: "filename"
@@ -390,7 +388,6 @@ paths:
       security:
       - api_key: []
     options:
-      summary: "CORS support"
       parameters:
       - name: "filename"
         in: "path"
@@ -419,7 +416,40 @@ paths:
           type: "string"
       responses:
         "200":
-          description: "Default response for CORS method"
+          description: "200 response"
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: "string"
+            Access-Control-Allow-Methods:
+              schema:
+                type: "string"
+            Access-Control-Allow-Headers:
+              schema:
+                type: "string"
+          content: {}
+      security:
+      - api_key: []
+  /data-packages/{data_package_id}:
+    get:
+      parameters:
+      - name: "data_package_id"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      security:
+      - api_key: []
+    options:
+      parameters:
+      - name: "data_package_id"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      responses:
+        "200":
+          description: "200 response"
           headers:
             Access-Control-Allow-Origin:
               schema:
@@ -561,39 +591,6 @@ paths:
       - api_key: []
     options:
       summary: "CORS support"
-      responses:
-        "200":
-          description: "Default response for CORS method"
-          headers:
-            Access-Control-Allow-Origin:
-              schema:
-                type: "string"
-            Access-Control-Allow-Methods:
-              schema:
-                type: "string"
-            Access-Control-Allow-Headers:
-              schema:
-                type: "string"
-          content: {}
-      security:
-      - api_key: []
-  /data_packages/{data_package_id}:
-    get:
-      parameters:
-      - name: "data_package_id"
-        in: "path"
-        required: true
-        schema:
-          type: "string"
-      security:
-      - api_key: []
-    options:
-      parameters:
-      - name: "data_package_id"
-        in: "path"
-        required: true
-        schema:
-          type: "string"
       responses:
         "200":
           description: "Default response for CORS method"

--- a/scripts/migrations/migration.004.s3_name_with_id.py
+++ b/scripts/migrations/migration.004.s3_name_with_id.py
@@ -29,15 +29,14 @@ def s3_name_with_id(bucket: str):
     contents = res["Contents"]
     moved_files = 0
     for s3_file in contents:
-        if s3_file["Key"].split("/")[0] == "aggregates":
-            key = s3_file["Key"]
-            key_array = key.split("/")
-            if len(key_array[3]) == 3:
-                key_array[3] = f"{key_array[2]}_{key_array[3]}"
-                new_key = "/".join(key_array)
-                client.copy({"Bucket": bucket, "Key": key}, bucket, new_key)
-                client.delete_object(Bucket=bucket, Key=key)
-                moved_files += 1
+        key = s3_file["Key"]
+        key_array = key.split("/")
+        if key_array[0] == "aggregates" and len(key_array[3]) == 3:
+            key_array[3] = f"{key_array[2]}__{key_array[3]}"
+            new_key = "/".join(key_array)
+            client.copy({"Bucket": bucket, "Key": key}, bucket, new_key)
+            client.delete_object(Bucket=bucket, Key=key)
+            moved_files += 1
     print(f"Updated {moved_files} aggregates")
 
 

--- a/scripts/migrations/migration.004.s3_name_with_id.py
+++ b/scripts/migrations/migration.004.s3_name_with_id.py
@@ -1,0 +1,48 @@
+"""Removes unexpected root nodes/templates/misspelled keys from transaction log."""
+
+import argparse
+import io
+import json
+
+import boto3
+
+
+def _get_s3_data(key: str, bucket_name: str, client) -> dict:
+    """Convenience class for retrieving a dict from S3"""
+    try:
+        bytes_buffer = io.BytesIO()
+        client.download_fileobj(Bucket=bucket_name, Key=key, Fileobj=bytes_buffer)
+        return json.loads(bytes_buffer.getvalue().decode())
+    except Exception:  # pylint: disable=broad-except
+        return {}
+
+
+def _put_s3_data(key: str, bucket_name: str, client, data: dict) -> None:
+    """Convenience class for writing a dict to S3"""
+    b_data = io.BytesIO(json.dumps(data).encode())
+    client.upload_fileobj(Bucket=bucket_name, Key=key, Fileobj=b_data)
+
+
+def s3_name_with_id(bucket: str):
+    client = boto3.client("s3")
+    res = client.list_objects_v2(Bucket=bucket)
+    contents = res["Contents"]
+    moved_files = 0
+    for s3_file in contents:
+        if s3_file["Key"].split("/")[0] == "aggregates":
+            key = s3_file["Key"]
+            key_array = key.split("/")
+            if len(key_array[3]) == 3:
+                key_array[3] = f"{key_array[2]}_{key_array[3]}"
+                new_key = "/".join(key_array)
+                client.copy({"Bucket": bucket, "Key": key}, bucket, new_key)
+                client.delete_object(Bucket=bucket, Key=key)
+                moved_files += 1
+    print(f"Updated {moved_files} aggregates")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="""Changes lowest directory in S3 to file id""")
+    parser.add_argument("-b", "--bucket", help="bucket name")
+    args = parser.parse_args()
+    s3_name_with_id(args.bucket)

--- a/src/handlers/dashboard/get_data_packages.py
+++ b/src/handlers/dashboard/get_data_packages.py
@@ -26,7 +26,7 @@ def data_packages_handler(event, context):
     elif event.get("pathParameters"):
         found = None
         for package in data_packages:
-            if event["pathParameters"]["id"] == package["id"]:
+            if event["pathParameters"]["data_package_id"] == package["id"]:
                 found = package
         if found:
             payload = found

--- a/src/handlers/shared/errors.py
+++ b/src/handlers/shared/errors.py
@@ -1,0 +1,2 @@
+class AggregatorS3Error(Exception):
+    """Errors related to accessing files in S3"""

--- a/src/handlers/site_upload/powerset_merge.py
+++ b/src/handlers/site_upload/powerset_merge.py
@@ -44,7 +44,7 @@ class S3Manager:
         self.study = s3_key_array[1]
         self.data_package = s3_key_array[2].split("__")[1]
         self.site = s3_key_array[3]
-        self.version = s3_key_array[4][-3:]
+        self.version = s3_key_array[4].split("__")[-1]
         self.metadata = functions.read_metadata(self.s3_client, self.s3_bucket_name)
         self.types_metadata = functions.read_metadata(
             self.s3_client,
@@ -87,7 +87,7 @@ class S3Manager:
         parquet_aggregate_path = (
             f"s3://{self.s3_bucket_name}/{enums.BucketPath.AGGREGATE.value}/"
             f"{self.study}/{self.study}__{self.data_package}/"
-            f"{self.study}__{self.data_package}_{self.version}/"
+            f"{self.study}__{self.data_package}__{self.version}/"
             f"{self.study}__{self.data_package}__aggregate.parquet"
         )
         awswrangler.s3.to_parquet(df, parquet_aggregate_path, index=False)

--- a/src/handlers/site_upload/powerset_merge.py
+++ b/src/handlers/site_upload/powerset_merge.py
@@ -44,7 +44,7 @@ class S3Manager:
         self.study = s3_key_array[1]
         self.data_package = s3_key_array[2].split("__")[1]
         self.site = s3_key_array[3]
-        self.version = s3_key_array[4]
+        self.version = s3_key_array[4][-3:]
         self.metadata = functions.read_metadata(self.s3_client, self.s3_bucket_name)
         self.types_metadata = functions.read_metadata(
             self.s3_client,
@@ -53,7 +53,8 @@ class S3Manager:
         )
         self.csv_aggerate_path = (
             f"s3://{self.s3_bucket_name}/{enums.BucketPath.CSVAGGREGATE.value}/"
-            f"{self.study}/{self.study}__{self.data_package}/{self.version}/"
+            f"{self.study}/{self.study}__{self.data_package}/"
+            f"{self.version}/"
             f"{self.study}__{self.data_package}__aggregate.csv"
         )
 
@@ -85,7 +86,8 @@ class S3Manager:
         """writes dataframe as parquet to s3 and sends an SNS notification if new"""
         parquet_aggregate_path = (
             f"s3://{self.s3_bucket_name}/{enums.BucketPath.AGGREGATE.value}/"
-            f"{self.study}/{self.study}__{self.data_package}/{self.version}/"
+            f"{self.study}/{self.study}__{self.data_package}/"
+            f"{self.study}__{self.data_package}_{self.version}/"
             f"{self.study}__{self.data_package}__aggregate.parquet"
         )
         awswrangler.s3.to_parquet(df, parquet_aggregate_path, index=False)

--- a/template.yaml
+++ b/template.yaml
@@ -350,7 +350,7 @@ Resources:
           Type: Api
           Properties:
             RestApiId: !Ref DashboardApiGateway
-            Path: /data_packages/{data_package_id}/chart
+            Path: /data-packages/{data_package_id}/chart
             Method: GET
             RequestParameters: 
               - method.request.querystring.column:
@@ -417,7 +417,7 @@ Resources:
           Type: Api
           Properties:
             RestApiId: !Ref DashboardApiGateway
-            Path: /last_valid/{study}/{data_package}/{site}/{version}/{filename}
+            Path: /last-valid/{study}/{data_package}/{site}/{version}/{filename}
             Method: GET
       Policies:
         - S3ReadPolicy:
@@ -463,7 +463,7 @@ Resources:
           Type: Api
           Properties:
             RestApiId: !Ref DashboardApiGateway
-            Path: /last_valid/
+            Path: /last-valid/
             Method: GET
       Policies:
         - S3ReadPolicy:
@@ -571,7 +571,7 @@ Resources:
           Type: Api
           Properties:
             RestApiId: !Ref DashboardApiGateway
-            Path: /data_packages
+            Path: /data-packages
             Method: GET
             RequestParameters: 
               - method.request.querystring.name:
@@ -580,7 +580,7 @@ Resources:
           Type: Api
           Properties:
             RestApiId: !Ref DashboardApiGateway
-            Path: /data_packages/{data_package_id}
+            Path: /data-packages/{data_package_id}
             Method: GET
       # TODO: it :should: be possible to move these policies to a central role/policy
       # set that can be referenced in multiple places; see

--- a/template.yaml
+++ b/template.yaml
@@ -336,7 +336,7 @@ Resources:
       LoggingConfig:
         ApplicationLogLevel: !Ref LogLevel
         LogFormat: !Ref LogFormat
-        LogGroup: !Sub "/aws/lambda/CumulusAggDashboardGetChartDataFunction-${DeployStage}"
+        LogGroup: !Sub "/aws/lambda/CumulusAggDashboardGetChartData-${DeployStage}"
       MemorySize: 2048
       Timeout: 100
       Description: Retrieve data for chart display in Cumulus Dashboard
@@ -350,8 +350,13 @@ Resources:
           Type: Api
           Properties:
             RestApiId: !Ref DashboardApiGateway
-            Path: /chart-data/{subscription_name}
+            Path: /data_packages/{data_package_id}/chart
             Method: GET
+            RequestParameters: 
+              - method.request.querystring.column:
+                  Required: true
+              - method.request.querystring.filters:
+                  Required: false
       Policies:
         - S3CrudPolicy:
             BucketName: !Ref AggregatorBucket
@@ -575,7 +580,7 @@ Resources:
           Type: Api
           Properties:
             RestApiId: !Ref DashboardApiGateway
-            Path: /data_packages/{id}
+            Path: /data_packages/{data_package_id}
             Method: GET
       # TODO: it :should: be possible to move these policies to a central role/policy
       # set that can be referenced in multiple places; see
@@ -735,7 +740,7 @@ Resources:
       CatalogId: !Ref AWS::AccountId
       DatabaseInput:
         Name: !Sub '${GlueNameParameter}-${DeployStage}'
-        Description: Database for serving data to Cumulus Dashboard
+        Description: Database for serving data to the Cumulus Dashboard
 
   GlueCrawler:
     Type: AWS::Glue::Crawler
@@ -743,11 +748,11 @@ Resources:
       Name: !Sub '${GlueNameParameter}-crawler-${DeployStage}'
       DatabaseName: !Ref GlueDB
       Role: !GetAtt CrawlerRole.Arn
-      Configuration: "{\"Version\":1.0,\"Grouping\":{\"TableLevelConfiguration\":4}}"
+      Configuration: "{\"Version\":1.0,\"Grouping\":{\"TableLevelConfiguration\":5}}"
       RecrawlPolicy:
         RecrawlBehavior: CRAWL_EVERYTHING
       SchemaChangePolicy:
-        DeleteBehavior: DEPRECATE_IN_DATABASE
+        DeleteBehavior: DELETE_FROM_DATABASE
         UpdateBehavior: UPDATE_IN_DATABASE
       Schedule:
         ScheduleExpression: "cron(0 22 ? * SUN *)"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,7 +49,8 @@ def _init_mock_data(s3_client, bucket, study, data_package, version):
         "./tests/test_data/count_synthea_patient_agg.parquet",
         bucket,
         f"{enums.BucketPath.AGGREGATE.value}/{study}/"
-        f"{study}__{data_package}/{version}/{study}__{data_package}__aggregate.parquet",
+        f"{study}__{data_package}/{study}__{data_package}_{version}/"
+        f"{study}__{data_package}__aggregate.parquet",
     )
     s3_client.upload_file(
         "./tests/test_data/count_synthea_patient_agg.csv",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,7 +49,7 @@ def _init_mock_data(s3_client, bucket, study, data_package, version):
         "./tests/test_data/count_synthea_patient_agg.parquet",
         bucket,
         f"{enums.BucketPath.AGGREGATE.value}/{study}/"
-        f"{study}__{data_package}/{study}__{data_package}_{version}/"
+        f"{study}__{data_package}/{study}__{data_package}__{version}/"
         f"{study}__{data_package}__aggregate.parquet",
     )
     s3_client.upload_file(

--- a/tests/dashboard/test_get_chart_data.py
+++ b/tests/dashboard/test_get_chart_data.py
@@ -104,8 +104,8 @@ def test_format_payload(query_params, filters, expected_payload):
 
 
 def test_get_data_cols(mock_bucket):
-    table_name = f"{EXISTING_STUDY}__{EXISTING_DATA_P}_{EXISTING_VERSION}"
-    res = get_chart_data._get_table_cols(table_name)
+    table_id = f"{EXISTING_STUDY}__{EXISTING_DATA_P}__{EXISTING_VERSION}"
+    res = get_chart_data._get_table_cols(table_id)
     cols = pandas.read_csv("./tests/test_data/count_synthea_patient_agg.csv").columns
     assert res == list(cols)
 

--- a/tests/dashboard/test_get_chart_data.py
+++ b/tests/dashboard/test_get_chart_data.py
@@ -9,6 +9,7 @@ from src.handlers.dashboard import get_chart_data
 from tests.mock_utils import (
     EXISTING_DATA_P,
     EXISTING_STUDY,
+    EXISTING_VERSION,
     MOCK_ENV,
     TEST_GLUE_DB,
 )
@@ -33,7 +34,7 @@ def mock_data_frame(filter_param):
         (
             {"column": "gender"},
             [],
-            {"data_package": "test_study"},
+            {"data_package_id": "test_study"},
             f'SELECT gender, sum(cnt) as cnt FROM "{TEST_GLUE_DB}"."test_study" '
             "WHERE COALESCE (race) IS NOT Null AND gender IS NOT Null  "
             "GROUP BY gender",
@@ -41,7 +42,7 @@ def mock_data_frame(filter_param):
         (
             {"column": "gender", "stratifier": "race"},
             [],
-            {"data_package": "test_study"},
+            {"data_package_id": "test_study"},
             f'SELECT race, gender, sum(cnt) as cnt FROM "{TEST_GLUE_DB}"."test_study" '
             "WHERE gender IS NOT Null  "
             "GROUP BY race, gender",
@@ -49,7 +50,7 @@ def mock_data_frame(filter_param):
         (
             {"column": "gender"},
             ["gender:strEq:female"],
-            {"data_package": "test_study"},
+            {"data_package_id": "test_study"},
             f'SELECT gender, sum(cnt) as cnt FROM "{TEST_GLUE_DB}"."test_study" '
             "WHERE COALESCE (race) IS NOT Null AND gender IS NOT Null "
             "AND gender LIKE 'female' "
@@ -58,7 +59,7 @@ def mock_data_frame(filter_param):
         (
             {"column": "gender", "stratifier": "race"},
             ["gender:strEq:female"],
-            {"data_package": "test_study"},
+            {"data_package_id": "test_study"},
             f'SELECT race, gender, sum(cnt) as cnt FROM "{TEST_GLUE_DB}"."test_study" '
             "WHERE gender IS NOT Null "
             "AND gender LIKE 'female' "
@@ -103,7 +104,7 @@ def test_format_payload(query_params, filters, expected_payload):
 
 
 def test_get_data_cols(mock_bucket):
-    table_name = f"{EXISTING_STUDY}__{EXISTING_DATA_P}"
+    table_name = f"{EXISTING_STUDY}__{EXISTING_DATA_P}_{EXISTING_VERSION}"
     res = get_chart_data._get_table_cols(table_name)
     cols = pandas.read_csv("./tests/test_data/count_synthea_patient_agg.csv").columns
     assert res == list(cols)

--- a/tests/dashboard/test_get_data_packages.py
+++ b/tests/dashboard/test_get_data_packages.py
@@ -22,11 +22,13 @@ def test_get_data_packages(mock_bucket):
     assert 2 == len(json.loads(res["body"]))
     for item in data:
         assert item["name"] == "encounter"
-    res = data_packages_handler({"pathParameters": {"id": "other_study__document__100"}}, {})
+    res = data_packages_handler(
+        {"pathParameters": {"data_package_id": "other_study__document__100"}}, {}
+    )
     data = json.loads(res["body"])
     assert res["statusCode"] == 200
     assert 9 == len(data)
     assert data["id"] == "other_study__document__100"
-    res = data_packages_handler({"pathParameters": {"id": "not_an_id"}}, {})
+    res = data_packages_handler({"pathParameters": {"data_package_id": "not_an_id"}}, {})
     data = json.loads(res["body"])
     assert res["statusCode"] == 404

--- a/tests/site_upload/test_powerset_merge.py
+++ b/tests/site_upload/test_powerset_merge.py
@@ -92,17 +92,17 @@ from tests.mock_utils import (
             200,
             ITEM_COUNT + 4,
         ),
-        # (  # ensuring that a data package that is a substring does not get
-        #     # merged by substr match
-        #     "./tests/test_data/count_synthea_patient.parquet",
-        #     f"/{EXISTING_STUDY}/{EXISTING_STUDY}__{EXISTING_DATA_P[0:-2]}/{EXISTING_SITE}/"
-        #     f"{EXISTING_STUDY}__{EXISTING_DATA_P[0:-2]}_{EXISTING_VERSION}/encount.parquet",
-        #     f"/{EXISTING_STUDY}/{EXISTING_STUDY}__{EXISTING_DATA_P[0:-2]}/"
-        #     f"{EXISTING_STUDY}__{EXISTING_DATA_P[0:-2]}_{EXISTING_VERSION}/encount.parquet",
-        #     False,
-        #     200,
-        #     ITEM_COUNT + 4,
-        # ),
+        (  # ensuring that a data package that is a substring does not get
+            # merged by substr match
+            "./tests/test_data/count_synthea_patient.parquet",
+            f"/{EXISTING_STUDY}/{EXISTING_STUDY}__{EXISTING_DATA_P[0:-2]}/{EXISTING_SITE}/"
+            f"{EXISTING_VERSION}/encount.parquet",
+            f"/{EXISTING_STUDY}/{EXISTING_STUDY}__{EXISTING_DATA_P[0:-2]}/{EXISTING_SITE}/"
+            f"{EXISTING_VERSION}/encount.parquet",
+            False,
+            200,
+            ITEM_COUNT + 4,
+        ),
         (  # Empty file upload
             None,
             f"/{NEW_STUDY}/{NEW_STUDY}__{EXISTING_DATA_P}/{EXISTING_SITE}"
@@ -136,7 +136,6 @@ def test_powerset_merge_single_upload(
     mock_notification,
 ):
     s3_client = boto3.client("s3", region_name="us-east-1")
-    s3_res = s3_client.list_objects_v2(Bucket=TEST_BUCKET)
     if upload_file is not None:
         s3_client.upload_file(
             upload_file,

--- a/tests/site_upload/test_powerset_merge.py
+++ b/tests/site_upload/test_powerset_merge.py
@@ -92,17 +92,17 @@ from tests.mock_utils import (
             200,
             ITEM_COUNT + 4,
         ),
-        (  # ensuring that a data package that is a substring does not get
-            # merged by substr match
-            "./tests/test_data/count_synthea_patient.parquet",
-            f"/{EXISTING_STUDY}/{EXISTING_STUDY}__{EXISTING_DATA_P[0:-2]}/"
-            f"{EXISTING_SITE}/{EXISTING_VERSION}/encount.parquet",
-            f"/{EXISTING_STUDY}/{EXISTING_STUDY}__{EXISTING_DATA_P[0:-2]}/"
-            f"{EXISTING_SITE}/{EXISTING_VERSION}/encount.parquet",
-            False,
-            200,
-            ITEM_COUNT + 4,
-        ),
+        # (  # ensuring that a data package that is a substring does not get
+        #     # merged by substr match
+        #     "./tests/test_data/count_synthea_patient.parquet",
+        #     f"/{EXISTING_STUDY}/{EXISTING_STUDY}__{EXISTING_DATA_P[0:-2]}/{EXISTING_SITE}/"
+        #     f"{EXISTING_STUDY}__{EXISTING_DATA_P[0:-2]}_{EXISTING_VERSION}/encount.parquet",
+        #     f"/{EXISTING_STUDY}/{EXISTING_STUDY}__{EXISTING_DATA_P[0:-2]}/"
+        #     f"{EXISTING_STUDY}__{EXISTING_DATA_P[0:-2]}_{EXISTING_VERSION}/encount.parquet",
+        #     False,
+        #     200,
+        #     ITEM_COUNT + 4,
+        # ),
         (  # Empty file upload
             None,
             f"/{NEW_STUDY}/{NEW_STUDY}__{EXISTING_DATA_P}/{EXISTING_SITE}"
@@ -136,6 +136,7 @@ def test_powerset_merge_single_upload(
     mock_notification,
 ):
     s3_client = boto3.client("s3", region_name="us-east-1")
+    s3_res = s3_client.list_objects_v2(Bucket=TEST_BUCKET)
     if upload_file is not None:
         s3_client.upload_file(
             upload_file,
@@ -164,7 +165,7 @@ def test_powerset_merge_single_upload(
         ]
     }
     # This array looks like:
-    # ['', 'study', 'package', 'site', 'file']
+    # ['', 'study', 'package', 'site', 'version','file']
     event_list = event_key.split("/")
     study = event_list[1]
     data_package = event_list[2]


### PR DESCRIPTION
- Moves the `/chart_data/` endpoint to `/data_packages/[data_package_id]/chart`
- chart data now accessed via id instead of name
- updated S3 storage and glue crawlers to use data_package_id
- migration for existing aggregates
- added specific error handling for files not found in S3
- some import cleanup