### PR TITLE
Promote some migrations to maintenance scripts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "aggregator"
+name = "cumulus-aggregator"
 requires-python = ">= 3.10"
 version = "0.3.0"
 # This project is designed to run on the AWS serverless application framework (SAM).
@@ -31,11 +31,8 @@ classifiers = [
 "Homepage" = "https://github.com/smart-on-fhir/cumulus-aggregator"
 
 [build-system]
-build-backend = "setuptools.build_meta"
-requires = [
-    "setuptools ~=63.2.0",
-    "wheel ~=0.37.1",
-]
+requires = ["flit_core >=3.4,<4"]
+build-backend = "flit_core.buildapi"
 
 [project.optional-dependencies]
 test = [
@@ -58,6 +55,8 @@ dev = [
     "sqlfluff >= 3.2.5"
 ]
 
+[tool.flit.module]
+name = "src"
 [tool.coverage.run]
 omit = [
     "*/api_gateway_authorizer.py",

--- a/scripts/delete_site_data.py
+++ b/scripts/delete_site_data.py
@@ -1,0 +1,126 @@
+import argparse
+from collections import defaultdict
+
+import boto3
+from rich import console, progress, table
+
+from src.shared import enums
+
+site_artifacts = [enums.BucketPath.LAST_VALID.value]
+aggregates = [enums.BucketPath.AGGREGATE, enums.BucketPath.CSVAGGREGATE.value]
+
+
+def get_subbucket_contents(client, bucket, prefix):
+    res = client.list_objects_v2(Bucket=bucket, Prefix=prefix)
+    if "Contents" not in res.keys():
+        return []
+    files = [x["Key"] for x in res["Contents"]]
+    while res["IsTruncated"]:
+        res = client.list_objects_v2(
+            Bucket=bucket, Prefix=prefix, ContinuationToken=res["NextContinuationToken"]
+        )
+        files += [x["Key"] for x in res["Contents"]]
+    return files
+
+
+def cleanup_target(tree: dict, target: str, data_packages: str, site: str, version: str):
+    other_sites = list(tree[data_packages].keys())
+    other_sites.remove(site)
+    for site in other_sites:
+        for data_version in tree[data_packages][site].keys():
+            if data_version == version:
+                return tree[data_packages][site][data_version], None
+    return None, (
+        f"aggregates/{target}/{data_packages}/{data_packages}__{version}/"
+        f"{data_packages}__aggregate.parquet"
+    )
+
+
+def remove_site_data(bucket: str, target: str, site: str, version: str):
+    client = boto3.client("s3")
+    contents = get_subbucket_contents(client, bucket, enums.BucketPath.LAST_VALID.value)
+    tree = defaultdict(lambda: defaultdict(dict))
+    for path in contents:
+        s3_key = path.split("/")
+        if target == s3_key[1]:
+            tree[s3_key[2]][s3_key[3]][s3_key[4]] = path
+    data_packages_to_prune = []
+    regen_targets = []
+    delete_targets = []
+    for data_packages in tree.keys():
+        if site in tree[data_packages].keys():
+            for data_version in tree[data_packages][site].keys():
+                if version is None or data_version == version:
+                    regen_target, delete_target = cleanup_target(
+                        tree, target, data_packages, site, data_version
+                    )
+                    if regen_target:
+                        regen_targets.append(regen_target)
+                        data_packages_to_prune.append(
+                            ((tree[data_packages][site][data_version]), "Regen")
+                        )
+                    if delete_target:
+                        delete_targets.append(delete_target)
+                        data_packages_to_prune.append(
+                            ((tree[data_packages][site][data_version]), "Delete")
+                        )
+    c = console.Console()
+    if len(data_packages_to_prune) == 0:
+        c.print(f"No data found for {site} {target}.")
+        exit()
+    t = table.Table(title="Data cleanup summary")
+    t.add_column("Site")
+    t.add_column("Study")
+    t.add_column("Version")
+    t.add_column("Removals")
+    t.add_column("Regens")
+    t.add_column("Deletes")
+    t.add_row(
+        site,
+        target,
+        version if version else "All",
+        str(len(data_packages_to_prune)),
+        str(len(regen_targets)),
+        str(len(delete_targets)),
+    )
+    c.print(t)
+    c.print("Proceed with cleanup? Y to proceed, D for details, any other value to quit.")
+    response = input()
+    if response.lower() == "d":
+        t = table.Table()
+        t.add_column("File to remove")
+        t.add_column("Mititgation strategy")
+        for file in data_packages_to_prune:
+            t.add_row(file[0], file[1])
+        c.print(t)
+        c.print("Proceed with cleanup? Y to proceed, any other value to quit.")
+        response = input()
+    if response.lower() != "y":
+        c.print("Skipping cleanup")
+        exit()
+    for file in progress.track(data_packages_to_prune, description="Deleting objects..."):
+        client.delete_object(Bucket=bucket, Key=file[0])
+    for key in progress.track(regen_targets, description="Regenerating objects"):
+        client.copy(
+            CopySource={"Bucket": bucket, "Key": key},
+            Bucket=bucket,
+            Key=key.replace(enums.BucketPath.LAST_VALID.value, enums.BucketPath.UPLOAD.value, 1),
+        )
+    for key in delete_targets:
+        client.delete_object(Bucket=bucket, Key=key)
+    c.print("""Cleanup complete.
+
+You may need to run this again due to bucket backup policy reasons.
+Don't forget to rerun the glue crawler.""")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="""Removes artifacts from a site for a given study. """
+    )
+    parser.add_argument("-b", "--bucket", help="bucket name", required=True)
+    parser.add_argument("-t", "--target", help="target study", required=True)
+    parser.add_argument("-s", "--site", help="site data to remove", required=True)
+    parser.add_argument("-v", "--version", help="Specific version of data to remove (optional)")
+    args = parser.parse_args()
+    remove_site_data(args.bucket, args.target, args.site, args.version)

--- a/scripts/migrations/MAINTAINER.md
+++ b/scripts/migrations/MAINTAINER.md
@@ -1,6 +1,0 @@
-As of this writing, migration #3 is safe to run any time you need 
-to regenerate the table column type data/data package cache (i.e. 
-if things are deleted, or in response to bugs in this process).
-You should run the appropriate crawler first.
-
-Migration #5 should be evergreen for managing removal of site data from S3.

--- a/scripts/migrations/migration.003.data_packages.py
+++ b/scripts/migrations/migration.003.data_packages.py
@@ -1,3 +1,7 @@
+"""this migration is the basis of reset_data_package_cache - it is kept around
+mostly as a historical artifact of how migrations were run until then/utility
+for quickly cribbing together new migrations through reuse."""
+
 import argparse
 import enum
 import io

--- a/scripts/migrations/migration.005.remove_site_data.py
+++ b/scripts/migrations/migration.005.remove_site_data.py
@@ -1,3 +1,7 @@
+"""this migration is the basis of delete_site_data - it is kept around
+mostly as a historical artifact of how deletions were run until then/utility
+for quickly cribbing together new migrations through reuse."""
+
 import argparse
 import enum
 from collections import defaultdict

--- a/scripts/migrations/migration.006.rename_flat_csvs.py
+++ b/scripts/migrations/migration.006.rename_flat_csvs.py
@@ -18,9 +18,7 @@ def rename_csvs(bucket):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
-        description="""Removes artifacts from a site for a given study. """
-    )
+    parser = argparse.ArgumentParser(description="""Renames flat csv files in s3. """)
     parser.add_argument("-b", "--bucket", help="bucket name")
     parser.add_argument("-d", "--db", help="database name")
     args = parser.parse_args()

--- a/scripts/reset_data_package_cache.py
+++ b/scripts/reset_data_package_cache.py
@@ -1,0 +1,91 @@
+"""Util script for regenerating the list of data packages from data"""
+
+import argparse
+import io
+import json
+import os
+
+import boto3
+import pandas
+from rich import progress
+
+from src.shared import enums, pandas_functions
+from src.site_upload.cache_api import cache_api
+
+
+def _put_s3_data(key: str, bucket_name: str, client, data: dict) -> None:
+    """Convenience class for writing a dict to S3"""
+    b_data = io.BytesIO(json.dumps(data, indent=2).encode())
+    client.upload_fileobj(Bucket=bucket_name, Key=key, Fileobj=b_data)
+
+
+def update_column_type_metadata(bucket: str, client):
+    """creates a new metadata dict for column types.
+
+    By design, this will replaces an existing column type dict if one already exists.
+    """
+    output = {}
+    for subbucket in ["aggregates", "flat"]:
+        res = client.list_objects_v2(Bucket=bucket, Prefix=f"{subbucket}/")
+        contents = res.get("Contents", [])
+        for resource in progress.track(contents, description=f"Processing {subbucket}"):
+            dirs = resource["Key"].split("/")
+            study = dirs[1]
+            if subbucket == "aggregates":
+                data_package = dirs[2].split("__")[1]
+            elif subbucket == "flat":
+                data_package = dirs[3].split("__")[1]
+            version = dirs[3]
+            bytes_buffer = io.BytesIO()
+            client.download_fileobj(Bucket=bucket, Key=resource["Key"], Fileobj=bytes_buffer)
+            df = pandas.read_parquet(bytes_buffer)
+            type_dict = pandas_functions.get_column_datatypes(df.dtypes)
+            output.setdefault(study, {})
+            output[study].setdefault(data_package, {})
+            output[study][data_package].setdefault(version, {})
+            output[study][data_package][version]["column_types_format_version"] = 2
+            output[study][data_package][version]["columns"] = type_dict
+            output[study][data_package][version]["last_data_update"] = (
+                resource["LastModified"].now().isoformat()
+            )
+            output[study][data_package][version]["s3_path"] = resource["Key"]
+            if subbucket == "aggregates":
+                output[study][data_package][version]["total"] = int(df["cnt"][0])
+            elif subbucket == "flat":
+                output[study][data_package][version]["type"] = "flat"
+                output[study][data_package][version]["site"] = dirs[2]
+                output[study][data_package][version]["total"] = len(df)
+    _put_s3_data("metadata/column_types.json", bucket, client, output)
+
+
+def get_s3_json_as_dict(bucket, key: str):
+    """reads a json object as dict (typically metadata in this case)"""
+    s3_client = boto3.client("s3")
+    bytes_buffer = io.BytesIO()
+    s3_client.download_fileobj(
+        Bucket=bucket,
+        Key=key,
+        Fileobj=bytes_buffer,
+    )
+    return json.loads(bytes_buffer.getvalue().decode())
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="""Creates data package metadata for existing aggregates. """
+    )
+    parser.add_argument("-b", "--bucket", help="bucket name")
+    parser.add_argument("-d", "--db", help="database name")
+    args = parser.parse_args()
+    s3_client = boto3.client("s3")
+    update_column_type_metadata(args.bucket, s3_client)
+    env_cache = dict(os.environ)
+    try:
+        # mock some env vars assumed to be set inside a lambda env
+        os.environ["BUCKET_NAME"] = args.bucket
+        cache_api.cache_api_data(
+            s3_client, args.bucket, args.db, enums.JsonFilename.DATA_PACKAGES.value
+        )
+    finally:
+        os.environ.clear()
+        os.environ.update(env_cache)

--- a/src/dashboard/get_from_parquet/get_from_parquet.py
+++ b/src/dashboard/get_from_parquet/get_from_parquet.py
@@ -30,7 +30,16 @@ def from_parquet_handler(event, context):
         # TODO: this should be converted to a streamingresponse at some point
         # https://github.com/awslabs/aws-lambda-web-adapter/tree/main/examples/fastapi-response-streaming
         return functions.http_response(
-            200, payload, extra_headers={"Content-Type": "text/csv"}, skip_convert=True
+            200,
+            payload,
+            extra_headers={
+                "Content-Type": "text/csv",
+                "Content-disposition": (
+                    f"attachment; filename={s3_path.split('/')[-1].replace('.parquet','.csv')}"
+                ),
+                "Content-Length": len(payload.encode("UTF-8")),
+            },
+            skip_convert=True,
         )
     else:
         return functions.http_response(

--- a/src/site_upload/cache_api/cache_api.py
+++ b/src/site_upload/cache_api/cache_api.py
@@ -57,7 +57,7 @@ def cache_api_data(s3_client, s3_bucket_name: str, db: str, target: str) -> None
                 "id": f"{dp_detail['study']}__{dp_detail['name']}__{version}",
             }
             if "__flat" in dp_dict["s3_path"]:  # pragma: no cover
-                site = dp_dict["s3_path"].split("/")[5]
+                site = dp_dict["s3_path"].split("/")[2]
                 dp_dict["type"] = "flat"
                 dp_dict["site"] = site
                 dp_dict["id"] = dp_dict["id"] + f"__{site}"

--- a/tests/dashboard/test_get_from_parquet.py
+++ b/tests/dashboard/test_get_from_parquet.py
@@ -95,6 +95,7 @@ def test_get_data_packages(mock_bucket, target, payload_type, code, length, firs
     assert (res["statusCode"]) == code
     if code == 200:
         if payload_type is None or payload_type == "json":
+            assert res["headers"] == {"Content-Type": "application/json"}
             res = json.loads(res["body"])
             assert res["schema"]["fields"] == [
                 {"name": "cnt", "type": "integer", "extDtype": "Int64"},
@@ -105,6 +106,11 @@ def test_get_data_packages(mock_bucket, target, payload_type, code, length, firs
             ]
             res = res["data"]
         else:
+            assert res["headers"] == {
+                "Content-Type": "text/csv",
+                "Content-disposition": "attachment; filename=study__encounter__aggregate.csv",
+                "Content-Length": len(res["body"].encode("utf-8")),
+            }
             res = res["body"].split("\n")[:-1]
         assert len(res) == length
         assert res[0] == first


### PR DESCRIPTION
This makes the following changes:
- Moves reused migrations to two more permanent maintenance scripts
  - Reuses code from aggregator rather than creating parallel infrastructure, where possible
  - Changes the packager to better support these imports
- Fixes some sloppy naming/copy errors in migration 6, for posterity
- Gets correct value for site names in caching flat files
- Updates some csv headers by request