### PR TITLE
Fixed casting issue in chart data endpoint

### DIFF
--- a/src/dashboard/get_chart_data/templates/get_chart_data.sql.jinja
+++ b/src/dashboard/get_chart_data/templates/get_chart_data.sql.jinja
@@ -20,7 +20,7 @@ WHERE
     AND{%- endif %} "{{ data_column }}" IS NOT NULL
     AND (
         (
-            {{ data_column }} != 'cumulus__none'
+            CAST("{{ data_column }}" AS VARCHAR) != 'cumulus__none'
             {%- if inline_configs|length > 0 %}
                 AND
                 (
@@ -29,7 +29,7 @@ WHERE
             {%- endif %}
         )
         OR (
-            {{ data_column }} = 'cumulus__none'
+            CAST("{{ data_column }}" AS VARCHAR) = 'cumulus__none'
             {%- if none_configs|length > 0 %}
                 AND
                 (

--- a/tests/dashboard/test_get_chart_data.py
+++ b/tests/dashboard/test_get_chart_data.py
@@ -227,3 +227,16 @@ def test_query_results(mock_db, mock_bucket, query_params, filter_groups, expect
     assert len(res) == len(expected)
     for i in range(0, len(res)):
         assert res[i] == expected[i]
+
+
+# while duckdb can handle boolean to string equality comparisons, athena does not.
+# So, we'll validate that casts show up for cumulus__none checks.
+@mock.patch(
+    "src.dashboard.get_chart_data.get_chart_data._get_table_cols", mock_get_table_cols_results
+)
+def test_cast_filter(mock_db, mock_bucket):
+    query, count_col = get_chart_data._build_query(
+        {"column": "nato"}, ["bool:isTrue"], {"data_package_id": "test__cube__001"}
+    )
+    assert """CAST("nato" AS VARCHAR) != 'cumulus__none'""" in query
+    assert """CAST("nato" AS VARCHAR) = 'cumulus__none'""" in query


### PR DESCRIPTION
This fixes #157 by ensuring that columns are cast to strings when they are checked for equality against `cumulus_none`.