### PR TITLE
Better handling of per-site flat files

### DIFF
--- a/scripts/migrations/migration.007.split_flats.py
+++ b/scripts/migrations/migration.007.split_flats.py
@@ -1,0 +1,31 @@
+import argparse
+
+import boto3
+from rich import progress
+
+
+def split_flats(bucket):
+    client = boto3.client("s3")
+    for prefix in ["flat", "csv_flat"]:
+        res = client.list_objects_v2(Bucket=bucket, Prefix=prefix)
+        for file in progress.track(res.get("Contents", []), description=f"moving {prefix}s..."):
+            split_key = file["Key"].split("/")
+            package = split_key[3].split("__")[1]
+            site = split_key[4].split("__")[1].replace(f"{package}_", "")
+            split_key[3] = split_key[3].split("__")
+            split_key[3].insert(2, site)
+            split_key[3] = "__".join(split_key[3])
+
+            client.copy(
+                {"Bucket": bucket, "Key": file["Key"]},
+                bucket,
+                "/".join(split_key),
+            )
+            client.delete_object(Bucket=bucket, Key=file["Key"])
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="""Adds site-level splits to flat files in s3. """)
+    parser.add_argument("-b", "--bucket", help="bucket name")
+    args = parser.parse_args()
+    split_flats(args.bucket)

--- a/src/dashboard/get_from_parquet/get_from_parquet.py
+++ b/src/dashboard/get_from_parquet/get_from_parquet.py
@@ -1,5 +1,3 @@
-import os
-
 import awswrangler
 import pyarrow
 
@@ -10,10 +8,9 @@ from shared import decorators, functions
 def from_parquet_handler(event, context):
     """manages event and returns parquet file as json dict"""
     del context
-    s3_bucket_name = os.environ.get("BUCKET_NAME")
     try:
         s3_path = event["queryStringParameters"]["s3_path"]
-        df = awswrangler.s3.read_parquet(f"s3://{s3_bucket_name}/{s3_path}")
+        df = awswrangler.s3.read_parquet(s3_path)
     except (KeyError, FileNotFoundError, pyarrow.lib.ArrowInvalid):
         res = functions.http_response(404, "S3_path not found")
         return res

--- a/src/shared/functions.py
+++ b/src/shared/functions.py
@@ -139,7 +139,10 @@ def update_metadata(
             data_version_metadata[target] = dt.isoformat()
         case enums.JsonFilename.COLUMN_TYPES.value:
             study_metadata = metadata.setdefault(study, {})
-            data_package_metadata = study_metadata.setdefault(data_package, {})
+            if extra_items.get("type") == "flat":
+                data_package_metadata = study_metadata.setdefault(f"{data_package}__{site}", {})
+            else:
+                data_package_metadata = study_metadata.setdefault(data_package, {})
             data_version_metadata = _update_or_clone_template(
                 data_package_metadata, version, COLUMN_TYPES_METADATA_TEMPLATE
             )
@@ -307,7 +310,7 @@ def parse_s3_key(key: str) -> PackageMetadata:
                     study=key[1],
                     site=key[2],
                     data_package=key[3].split("__")[1],
-                    version=key[3].split("__")[2],
+                    version=key[3].split("__")[3],
                 )
             case enums.BucketPath.UPLOAD.value:
                 package = PackageMetadata(
@@ -319,7 +322,7 @@ def parse_s3_key(key: str) -> PackageMetadata:
             case _:
                 raise errors.AggregatorS3Error(f" {key[0]} does not correspond to a data package")
         if "__" in package.version:
-            package.version = package.version.split("__")[2]
+            package.version = package.version.split("__")[-1]
         return package
     except IndexError:
         raise errors.AggregatorS3Error(f"{key} is not an expected S3 key")

--- a/src/shared/s3_manager.py
+++ b/src/shared/s3_manager.py
@@ -64,14 +64,14 @@ class S3Manager:
         self.parquet_flat_key = (
             f"{enums.BucketPath.FLAT.value}/"
             f"{self.study}/{self.site}/"  # {self.study}__{self.data_package}/"
-            f"{self.study}__{self.data_package}__{self.version}/"
-            f"{self.study}__{self.data_package}_{self.site}__flat.parquet"
+            f"{self.study}__{self.data_package}__{self.site}__{self.version}/"
+            f"{self.study}__{self.data_package}__{self.site}__flat.parquet"
         )
         self.csv_flat_key = (
             f"{enums.BucketPath.CSVFLAT.value}/"
             f"{self.study}/{self.site}/"  # {self.study}__{self.data_package}/"
-            f"{self.study}__{self.data_package}__{self.version}/"
-            f"{self.study}__{self.data_package}_{self.site}__flat.csv"
+            f"{self.study}__{self.data_package}__{self.site}__{self.version}/"
+            f"{self.study}__{self.data_package}__{self.site}__flat.csv"
         )
 
     def error_handler(
@@ -203,7 +203,10 @@ class S3Manager:
         # are tied to the study version, not a specific site's data
         if extra_items is None:
             extra_items = {}
-        if site is None and meta_type != enums.JsonFilename.COLUMN_TYPES.value:
+        if site is None and (
+            meta_type != enums.JsonFilename.COLUMN_TYPES.value
+            or extra_items.get("type", "") == "flat"
+        ):
             site = self.site
         if metadata is None:
             metadata = self.metadata

--- a/src/site_upload/process_flat/process_flat.py
+++ b/src/site_upload/process_flat/process_flat.py
@@ -33,17 +33,18 @@ def process_flat(manager: s3_manager.S3Manager):
     )
     df = awswrangler.s3.read_parquet(f"s3://{manager.s3_bucket_name}/{manager.parquet_flat_key}")
     column_dict = pandas_functions.get_column_datatypes(df.dtypes)
+    extras = {
+        "s3_path": f"s3://{manager.s3_bucket_name}/{manager.parquet_flat_key}",
+        "type": "flat",
+        "total": len(df),
+    }
     manager.update_local_metadata(
         enums.ColumnTypesKeys.COLUMNS.value,
         value=column_dict,
         site=manager.site,
         metadata=manager.types_metadata,
         meta_type=enums.JsonFilename.COLUMN_TYPES.value,
-        extra_items={
-            "s3_path": f"s3://{manager.s3_bucket_name}/{manager.parquet_flat_key}",
-            "type": "flat",
-            "total": len(df),
-        },
+        extra_items=extras,
     )
     manager.update_local_metadata(enums.TransactionKeys.LAST_DATA_UPDATE.value, site=manager.site)
     manager.update_local_metadata(
@@ -51,6 +52,7 @@ def process_flat(manager: s3_manager.S3Manager):
         value=column_dict,
         metadata=manager.types_metadata,
         meta_type=enums.JsonFilename.COLUMN_TYPES.value,
+        extra_items=extras,
     )
     manager.write_local_metadata(
         metadata=manager.types_metadata, meta_type=enums.JsonFilename.COLUMN_TYPES.value

--- a/template.yaml
+++ b/template.yaml
@@ -1023,7 +1023,6 @@ Resources:
 
 ### Proxy Bindings
 # These add proxy endpoints to the fanout proxies created in proxy.yaml
-# If you don't need to run multiple network configurations, you can comment these out
 
   NetworkSiteResource:
     Type: AWS::ApiGateway::Resource

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,14 +67,14 @@ def _init_mock_data(s3_client, bucket, study, data_package, version):
         "./tests/test_data/flat_synthea_q_date_recent.parquet",
         bucket,
         f"{enums.BucketPath.FLAT.value}/{study}/{mock_utils.EXISTING_SITE}/"
-        f"{study}__{data_package}_flat__{version}/"
+        f"{study}__{data_package}__{mock_utils.EXISTING_SITE}__{version}/"
         f"{study}__{data_package}__flat.parquet",
     )
     s3_client.upload_file(
         "./tests/test_data/flat_synthea_q_date_recent.csv",
         bucket,
         f"{enums.BucketPath.CSVFLAT.value}/{study}/{mock_utils.EXISTING_SITE}/"
-        f"{study}__{data_package}_flat__{version}/"
+        f"{study}__{data_package}__{mock_utils.EXISTING_SITE}__{version}/"
         f"{study}__{data_package}__flat.csv",
     )
     s3_client.upload_file(

--- a/tests/dashboard/test_get_from_parquet.py
+++ b/tests/dashboard/test_get_from_parquet.py
@@ -5,7 +5,7 @@ from unittest import mock
 import pytest
 
 from src.dashboard.get_from_parquet import get_from_parquet
-from tests.mock_utils import MOCK_ENV
+from tests.mock_utils import MOCK_ENV, TEST_BUCKET
 
 
 def mock_event(target, payload_type):
@@ -17,9 +17,7 @@ def mock_event(target, payload_type):
     return payload
 
 
-S3_PATH = (
-    "aggregates/study/study__encounter/study__encounter__099/study__encounter__aggregate.parquet"
-)
+S3_PATH = f"s3://{TEST_BUCKET}/aggregates/study/study__encounter/study__encounter__099/study__encounter__aggregate.parquet"
 
 
 @pytest.mark.parametrize(

--- a/tests/shared/test_functions.py
+++ b/tests/shared/test_functions.py
@@ -146,7 +146,8 @@ def test_latest_data_package_version(mock_bucket):
         (
             f"{enums.BucketPath.FLAT.value}/{mock_utils.EXISTING_STUDY}/"
             f"{mock_utils.EXISTING_SITE}/"
-            f"{mock_utils.EXISTING_STUDY}__{mock_utils.EXISTING_DATA_P}__{mock_utils.EXISTING_VERSION}/"
+            f"{mock_utils.EXISTING_STUDY}__{mock_utils.EXISTING_DATA_P}__"
+            f"{mock_utils.EXISTING_SITE}__{mock_utils.EXISTING_VERSION}/"
             f"{mock_utils.EXISTING_STUDY}__{mock_utils.EXISTING_DATA_P}__aggregate.parquet",
             functions.PackageMetadata(
                 mock_utils.EXISTING_STUDY,

--- a/tests/shared/test_s3_manager.py
+++ b/tests/shared/test_s3_manager.py
@@ -57,10 +57,14 @@ def test_init_manager(mock_bucket):
         == "s3://cumulus-aggregator-site-counts-test/csv_aggregates/study/study__encounter/099/study__encounter__aggregate.csv"
     )
     assert manager.parquet_flat_key == (
-        f"flat/study/{mock_utils.EXISTING_SITE}/{mock_utils.EXISTING_STUDY}__{mock_utils.EXISTING_DATA_P}__{mock_utils.EXISTING_VERSION}/{mock_utils.EXISTING_STUDY}__encounter_{mock_utils.EXISTING_SITE}__flat.parquet"
+        f"flat/study/{mock_utils.EXISTING_SITE}/{mock_utils.EXISTING_STUDY}__{mock_utils.EXISTING_DATA_P}"
+        f"__{mock_utils.EXISTING_SITE}__{mock_utils.EXISTING_VERSION}/"
+        f"{mock_utils.EXISTING_STUDY}__encounter__{mock_utils.EXISTING_SITE}__flat.parquet"
     )
     assert manager.csv_flat_key == (
-        f"csv_flat/study/{mock_utils.EXISTING_SITE}/{mock_utils.EXISTING_STUDY}__{mock_utils.EXISTING_DATA_P}__{mock_utils.EXISTING_VERSION}/{mock_utils.EXISTING_STUDY}__encounter_{mock_utils.EXISTING_SITE}__flat.csv"
+        f"csv_flat/study/{mock_utils.EXISTING_SITE}/"
+        f"{mock_utils.EXISTING_STUDY}__{mock_utils.EXISTING_DATA_P}__{mock_utils.EXISTING_SITE}__{mock_utils.EXISTING_VERSION}/"
+        f"{mock_utils.EXISTING_STUDY}__encounter__{mock_utils.EXISTING_SITE}__flat.csv"
     )
 
 

--- a/tests/site_upload/test_process_flat.py
+++ b/tests/site_upload/test_process_flat.py
@@ -14,7 +14,7 @@ def test_process_flat(mock_cache, mock_bucket):
                 "Sns": {
                     "TopicArn": "arn",
                     "Message": (
-                        "latest/study/study__encounter/site/study__encounter__version/file.parquet"
+                        "latest/study/study__encounter/site/study__encounter__site__version/file.parquet"
                     ),
                 }
             }
@@ -33,7 +33,9 @@ def test_process_flat(mock_cache, mock_bucket):
     files = [
         file["Key"] for file in s3_client.list_objects_v2(Bucket=mock_utils.TEST_BUCKET)["Contents"]
     ]
-    assert "flat/study/site/study__encounter__version/study__encounter_site__flat.parquet" in files
+    assert (
+        "flat/study/site/study__encounter__site__version/" "study__encounter__site__flat.parquet"
+    ) in files
 
     mock_cache.reset_mock()
     s3_client.upload_file(


### PR DESCRIPTION
This adds the site name to flat files as a way to preserve uniqueness between different instances of a type of flat file.

It also includes a migration of flat files to support this lookup, and various minor tweaks to flat file path handling.