### PR TITLE
Back to strings for column versions

### DIFF
--- a/scripts/migrations/migration.003.data_packages.py
+++ b/scripts/migrations/migration.003.data_packages.py
@@ -104,7 +104,7 @@ def update_column_type_metadata(bucket: str):
             output.setdefault(study, {})
             output[study].setdefault(data_package, {})
             output[study][data_package].setdefault(version, {})
-            output[study][data_package][version]["column_types_format_version"] = 2
+            output[study][data_package][version]["column_types_format_version"] = "2"
             output[study][data_package][version]["columns"] = type_dict
             output[study][data_package][version]["last_data_update"] = (
                 resource["LastModified"].now().isoformat()

--- a/scripts/reset_data_package_cache.py
+++ b/scripts/reset_data_package_cache.py
@@ -44,7 +44,7 @@ def update_column_type_metadata(bucket: str, client):
             output.setdefault(study, {})
             output[study].setdefault(data_package, {})
             output[study][data_package].setdefault(version, {})
-            output[study][data_package][version]["column_types_format_version"] = 2
+            output[study][data_package][version]["column_types_format_version"] = "2"
             output[study][data_package][version]["columns"] = type_dict
             output[study][data_package][version]["last_data_update"] = (
                 resource["LastModified"].now().isoformat()

--- a/tests/mock_utils.py
+++ b/tests/mock_utils.py
@@ -128,7 +128,7 @@ def get_mock_column_types_metadata():
         EXISTING_STUDY: {
             EXISTING_DATA_P: {
                 f"{EXISTING_STUDY}__{EXISTING_DATA_P}__{EXISTING_VERSION}": {
-                    "column_types_format_version": 2,
+                    "column_types_format_version": "2",
                     "columns": {
                         "cnt": "integer",
                         "gender": "string",
@@ -147,7 +147,7 @@ def get_mock_column_types_metadata():
                 },
                 EXISTING_FLAT_DATA_P: {
                     f"{EXISTING_STUDY}__{EXISTING_FLAT_DATA_P}__{EXISTING_VERSION}": {
-                        "column_types_format_version": 2,
+                        "column_types_format_version": "2",
                         "columns": {
                             "resource": "string",
                             "subgroup": "string",
@@ -173,7 +173,7 @@ def get_mock_column_types_metadata():
         OTHER_STUDY: {
             EXISTING_DATA_P: {
                 f"{OTHER_STUDY}__{EXISTING_DATA_P}__{EXISTING_VERSION}": {
-                    "column_types_format_version": 2,
+                    "column_types_format_version": "2",
                     "columns": {
                         "cnt": "integer",
                         "gender": "string",

--- a/tests/site_upload/test_cache_api.py
+++ b/tests/site_upload/test_cache_api.py
@@ -64,7 +64,7 @@ def test_cache_api_data(mock_bucket):
         {
             "study": "study",
             "name": "encounter",
-            "column_types_format_version": 2,
+            "column_types_format_version": "2",
             "columns": {
                 "cnt": "integer",
                 "gender": "string",


### PR DESCRIPTION
After seeing this pop up again, i did some global searches on versions - I think the change of string to int (which was only being done in the migrations) is more disruptive than changing int to string, so every instance now is configured to string versions.