### PR TITLE
add distinct value count to column_types

### DIFF
--- a/scripts/reset_data_package_cache.py
+++ b/scripts/reset_data_package_cache.py
@@ -40,11 +40,11 @@ def update_column_type_metadata(bucket: str, client):
             bytes_buffer = io.BytesIO()
             client.download_fileobj(Bucket=bucket, Key=resource["Key"], Fileobj=bytes_buffer)
             df = pandas.read_parquet(bytes_buffer)
-            type_dict = pandas_functions.get_column_datatypes(df.dtypes)
+            type_dict = pandas_functions.get_column_datatypes(df)
             output.setdefault(study, {})
             output[study].setdefault(data_package, {})
             output[study][data_package].setdefault(version, {})
-            output[study][data_package][version]["column_types_format_version"] = "2"
+            output[study][data_package][version]["column_types_format_version"] = "3"
             output[study][data_package][version]["columns"] = type_dict
             output[study][data_package][version]["last_data_update"] = (
                 resource["LastModified"].now().isoformat()

--- a/src/shared/functions.py
+++ b/src/shared/functions.py
@@ -31,7 +31,7 @@ STUDY_PERIOD_METADATA_TEMPLATE = {
 }
 
 COLUMN_TYPES_METADATA_TEMPLATE = {
-    enums.ColumnTypesKeys.COLUMN_TYPES_FORMAT_VERSION.value: "2",
+    enums.ColumnTypesKeys.COLUMN_TYPES_FORMAT_VERSION.value: "3",
     enums.ColumnTypesKeys.COLUMNS.value: None,
     enums.ColumnTypesKeys.LAST_DATA_UPDATE.value: None,
 }

--- a/src/shared/pandas_functions.py
+++ b/src/shared/pandas_functions.py
@@ -3,19 +3,20 @@
 import pandas
 
 
-def get_column_datatypes(dtypes: pandas.DataFrame):
+def get_column_datatypes(df: pandas.DataFrame):
     """helper for generating column type for dashboard API"""
     column_dict = {}
-    for column in dtypes.index:
+    for column in df.dtypes.index:
+        column_dict[column] = {}
         if column.endswith("year"):
-            column_dict[column] = "year"
+            column_dict[column]["type"] = "year"
         elif column.endswith("month"):
-            column_dict[column] = "month"
+            column_dict[column]["type"] = "month"
         elif column.endswith("week"):
-            column_dict[column] = "week"
-        elif column.endswith("day") or str(dtypes[column]).lower() == "datetime64":
-            column_dict[column] = "day"
-        elif column.startswith("cnt") or str(dtypes[column]).lower() in (
+            column_dict[column]["type"] = "week"
+        elif column.endswith("day") or str(df.dtypes[column]).lower() == "datetime64":
+            column_dict[column]["type"] = "day"
+        elif column.startswith("cnt") or str(df.dtypes[column]).lower() in (
             "int8",
             "int16",
             "int32",
@@ -25,13 +26,15 @@ def get_column_datatypes(dtypes: pandas.DataFrame):
             "uint32",
             "uint64",
         ):
-            column_dict[column] = "integer"
-        elif str(dtypes[column]).lower() in ("float32", "float64"):
-            column_dict[column] = "float"
-        elif str(dtypes[column]) == "boolean":
-            column_dict[column] = "boolean"
+            column_dict[column]["type"] = "integer"
+        elif str(df.dtypes[column]).lower() in ("float32", "float64"):
+            column_dict[column]["type"] = "float"
+        elif str(df.dtypes[column]) == "boolean":
+            column_dict[column]["type"] = "boolean"
         elif column in ["median", "average", "std_dev", "percentage"]:
-            column_dict[column] = "double"
+            column_dict[column]["type"] = "double"
         else:
-            column_dict[column] = "string"
+            column_dict[column]["type"] = "string"
+        if not column.startswith("cnt"):
+            column_dict[column]["distinct_values_count"] = df[column].nunique()
     return column_dict

--- a/src/site_upload/powerset_merge/powerset_merge.py
+++ b/src/site_upload/powerset_merge/powerset_merge.py
@@ -187,7 +187,7 @@ def merge_powersets(manager: s3_manager.S3Manager) -> None:
     manager.write_local_metadata()
 
     # Updating the typing dict for the column type API
-    column_dict = pandas_functions.get_column_datatypes(df.dtypes)
+    column_dict = pandas_functions.get_column_datatypes(df)
     manager.update_local_metadata(
         enums.ColumnTypesKeys.COLUMNS.value,
         value=column_dict,

--- a/src/site_upload/process_flat/process_flat.py
+++ b/src/site_upload/process_flat/process_flat.py
@@ -32,7 +32,7 @@ def process_flat(manager: s3_manager.S3Manager):
         f"s3://{manager.s3_bucket_name}/{manager.csv_flat_key}",
     )
     df = awswrangler.s3.read_parquet(f"s3://{manager.s3_bucket_name}/{manager.parquet_flat_key}")
-    column_dict = pandas_functions.get_column_datatypes(df.dtypes)
+    column_dict = pandas_functions.get_column_datatypes(df)
     extras = {
         "s3_path": f"s3://{manager.s3_bucket_name}/{manager.parquet_flat_key}",
         "type": "flat",

--- a/tests/shared/test_functions.py
+++ b/tests/shared/test_functions.py
@@ -59,17 +59,17 @@ def test_column_datatypes():
             "string": ["string"],
         }
     )
-    col_types = pandas_functions.get_column_datatypes(df.dtypes)
+    col_types = pandas_functions.get_column_datatypes(df)
     assert col_types == {
-        "study_year": "year",
-        "study_month": "month",
-        "study_week": "week",
-        "study_day": "day",
-        "cnt_item": "integer",
-        "int": "integer",
-        "float": "float",
-        "bool": "boolean",
-        "string": "string",
+        "study_year": {"type": "year", "distinct_values_count": 1},
+        "study_month": {"type": "month", "distinct_values_count": 1},
+        "study_week": {"type": "week", "distinct_values_count": 1},
+        "study_day": {"type": "day", "distinct_values_count": 1},
+        "cnt_item": {"type": "integer"},
+        "int": {"type": "integer", "distinct_values_count": 1},
+        "float": {"type": "float", "distinct_values_count": 1},
+        "bool": {"type": "boolean", "distinct_values_count": 1},
+        "string": {"type": "string", "distinct_values_count": 1},
     }
 
 


### PR DESCRIPTION
This updates the column_types to include a count of distinct values for each column, for the dashboard to use for making decisions about what kinds of previews to render (i.e. what's a reasonable stratifier).