### PR TITLE
Handle multiple files in previous uploads, remove CSVs

### DIFF
--- a/scripts/delete_site_data.py
+++ b/scripts/delete_site_data.py
@@ -7,7 +7,7 @@ from rich import console, progress, table
 from src.shared import enums
 
 site_artifacts = [enums.BucketPath.LAST_VALID.value]
-aggregates = [enums.BucketPath.AGGREGATE, enums.BucketPath.CSVAGGREGATE.value]
+aggregates = [enums.BucketPath.AGGREGATE.value]
 
 
 def get_subbucket_contents(client, bucket, prefix):

--- a/scripts/migrations/migration.008.remove_csvs.py
+++ b/scripts/migrations/migration.008.remove_csvs.py
@@ -1,0 +1,41 @@
+import argparse
+import enum
+
+import boto3
+from rich import progress
+
+
+class BucketPath(enum.Enum):
+    """stores root level buckets for managing data processing state"""
+
+    ADMIN = "admin"
+    AGGREGATE = "aggregates"
+    ARCHIVE = "archive"
+    CACHE = "cache"
+    CSVAGGREGATE = "csv_aggregates"
+    CSVFLAT = "csv_flat"
+    ERROR = "error"
+    FLAT = "flat"
+    LAST_VALID = "last_valid"
+    LATEST = "latest"
+    META = "metadata"
+    STUDY_META = "study_metadata"
+    UPLOAD = "site_upload"
+
+
+def remove_csvs(bucket):
+    client = boto3.client("s3")
+    # We specifically want to look at just the BucketPath folders since much of the
+    # raw athena data is stored in csvs, and we don't want to touch that
+    for base_folder in progress.track(BucketPath, description="Cleaning csvs..."):
+        res = client.list_objects_v2(Bucket=bucket, Prefix=base_folder.value)
+        for file in res.get("Contents", []):
+            if file["Key"].endswith(".csv"):
+                client.delete_object(Bucket=bucket, Key=file["Key"])
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="""Removes aggregator generated csvs. """)
+    parser.add_argument("-b", "--bucket", help="bucket name")
+    args = parser.parse_args()
+    remove_csvs(args.bucket)

--- a/src/shared/awswrangler_functions.py
+++ b/src/shared/awswrangler_functions.py
@@ -18,7 +18,7 @@ def get_s3_data_package_list(
     site: str | None = None,
 ):
     """Retrieves a list of data packages for a given S3 path post-upload processing"""
-    if bucket_root in [BucketPath.FLAT.value, BucketPath.CSVFLAT.value]:
+    if bucket_root == BucketPath.FLAT.value:
         return awswrangler.s3.list_objects(
             path=f"s3://{s3_bucket_name}/{bucket_root}/{study}/{site}/",
             suffix=extension,

--- a/src/shared/awswrangler_functions.py
+++ b/src/shared/awswrangler_functions.py
@@ -1,9 +1,6 @@
 """functions specifically requiring AWSWranger, which requires a lambda layer"""
 
-import csv
-
 import awswrangler
-import numpy
 
 from .enums import BucketPath
 
@@ -44,26 +41,4 @@ def get_s3_study_meta_list(
             f"{study}__{data_package}/{site}/{version}"
         ),
         suffix=extension,
-    )
-
-
-def generate_csv_from_parquet(
-    bucket_name: str, bucket_root: str, subbucket_path: str, to_path: str | None = None
-):
-    """Convenience function for generating csvs for dashboard upload
-
-    TODO: Remove on dashboard parquet/API support"""
-    if to_path is None:
-        to_path = f"s3://{bucket_name}/{bucket_root}/{subbucket_path}".replace(".parquet", ".csv")
-    last_valid_df = awswrangler.s3.read_parquet(
-        f"s3://{bucket_name}/{bucket_root}" f"/{subbucket_path}"
-    )
-    last_valid_df = last_valid_df.apply(lambda x: x.strip() if isinstance(x, str) else x).replace(
-        '""', numpy.nan
-    )
-    awswrangler.s3.to_csv(
-        last_valid_df,
-        to_path,
-        index=False,
-        quoting=csv.QUOTE_MINIMAL,
     )

--- a/src/shared/awswrangler_functions.py
+++ b/src/shared/awswrangler_functions.py
@@ -2,7 +2,7 @@
 
 import awswrangler
 
-from .enums import BucketPath
+from shared import enums, errors
 
 
 def get_s3_data_package_list(
@@ -10,18 +10,31 @@ def get_s3_data_package_list(
     s3_bucket_name: str,
     study: str,
     data_package: str,
+    *,
     extension: str = "parquet",
     version: str | None = None,
     site: str | None = None,
 ):
     """Retrieves a list of data packages for a given S3 path post-upload processing"""
-    if bucket_root == BucketPath.FLAT.value:
-        return awswrangler.s3.list_objects(
-            path=f"s3://{s3_bucket_name}/{bucket_root}/{study}/{site}/",
-            suffix=extension,
-        )
+    if bucket_root == enums.BucketPath.FLAT.value:
+        path = f"s3://{s3_bucket_name}/{bucket_root}/{study}/"
+        if site:
+            path += f"{site}/"
+            if version:
+                path += f"{version}/"
+    elif bucket_root in [
+        enums.BucketPath.AGGREGATE.value,
+        enums.BucketPath.LATEST.value,
+        enums.BucketPath.LAST_VALID.value,
+        enums.BucketPath.UPLOAD.value,
+    ]:
+        path = f"s3://{s3_bucket_name}/{bucket_root}/{study}/{study}__{data_package}/"
+        if version:
+            path += f"{version}/"
+    else:
+        raise errors.AggregatorS3Error(f"{bucket_root} does not contain data packages")
     return awswrangler.s3.list_objects(
-        path=f"s3://{s3_bucket_name}/{bucket_root}/{study}/{study}__{data_package}/",
+        path=path,
         suffix=extension,
     )
 
@@ -35,10 +48,11 @@ def get_s3_study_meta_list(
     extension: str = "parquet",
 ):
     """Retrieves metadata associated with a given upload"""
+    path = (
+        f"s3://{bucket_root}/{enums.BucketPath.STUDY_META.value}/{study}/"
+        f"{study}__{data_package}/{site}/{version}"
+    )
     return awswrangler.s3.list_objects(
-        path=(
-            f"s3://{bucket_root}/{BucketPath.STUDY_META.value}/{study}/"
-            f"{study}__{data_package}/{site}/{version}"
-        ),
+        path=path,
         suffix=extension,
     )

--- a/src/shared/enums.py
+++ b/src/shared/enums.py
@@ -10,8 +10,6 @@ class BucketPath(enum.Enum):
     AGGREGATE = "aggregates"
     ARCHIVE = "archive"
     CACHE = "cache"
-    CSVAGGREGATE = "csv_aggregates"
-    CSVFLAT = "csv_flat"
     ERROR = "error"
     FLAT = "flat"
     LAST_VALID = "last_valid"

--- a/src/shared/functions.py
+++ b/src/shared/functions.py
@@ -224,7 +224,7 @@ def get_s3_keys(
     return contents
 
 
-def get_s3_filename(s3_path: str):
+def get_filename_from_s3_path(s3_path: str):
     """Given an s3 path/key, returns the filename"""
     return s3_path.split("/")[-1]
 

--- a/src/shared/functions.py
+++ b/src/shared/functions.py
@@ -224,12 +224,9 @@ def get_s3_keys(
     return contents
 
 
-def get_s3_site_filename_suffix(s3_path: str):
-    """Extracts site/filename data from s3 path"""
-    # The expected s3 path for site data packages looks like:
-    #   s3://bucket_name/enum_value/site/study/data_package/file
-    # so this is returning data_package/file
-    return "/".join(s3_path.split("/")[-3:])
+def get_s3_filename(s3_path: str):
+    """ Given an s3 path/key, returns the filename"""    
+    return s3_path.split('/')[-1]
 
 
 def get_s3_key_from_path(s3_path: str):
@@ -283,6 +280,8 @@ class PackageMetadata:
 def parse_s3_key(key: str) -> PackageMetadata:
     """Handles extraction of package metadata from an s3 key"""
     try:
+        #did we get a full path instead?
+        key = get_s3_key_from_path(key)
         key = key.split("/")
         match key[0]:
             case enums.BucketPath.AGGREGATE.value | enums.BucketPath.CSVAGGREGATE.value:

--- a/src/shared/functions.py
+++ b/src/shared/functions.py
@@ -225,8 +225,8 @@ def get_s3_keys(
 
 
 def get_s3_filename(s3_path: str):
-    """ Given an s3 path/key, returns the filename"""    
-    return s3_path.split('/')[-1]
+    """Given an s3 path/key, returns the filename"""
+    return s3_path.split("/")[-1]
 
 
 def get_s3_key_from_path(s3_path: str):
@@ -280,11 +280,11 @@ class PackageMetadata:
 def parse_s3_key(key: str) -> PackageMetadata:
     """Handles extraction of package metadata from an s3 key"""
     try:
-        #did we get a full path instead?
+        # did we get a full path instead?
         key = get_s3_key_from_path(key)
         key = key.split("/")
         match key[0]:
-            case enums.BucketPath.AGGREGATE.value | enums.BucketPath.CSVAGGREGATE.value:
+            case enums.BucketPath.AGGREGATE.value:
                 package = PackageMetadata(
                     study=key[1],
                     site=None,
@@ -304,7 +304,7 @@ def parse_s3_key(key: str) -> PackageMetadata:
                     data_package=key[2].split("__")[1],
                     version=key[4],
                 )
-            case enums.BucketPath.CSVFLAT.value | enums.BucketPath.FLAT.value:
+            case enums.BucketPath.FLAT.value:
                 package = PackageMetadata(
                     study=key[1],
                     site=key[2],

--- a/src/site_upload/powerset_merge/powerset_merge.py
+++ b/src/site_upload/powerset_merge/powerset_merge.py
@@ -25,6 +25,7 @@ def get_static_string_series(static_str: str, index: RangeIndex) -> pandas.Serie
     """Helper for the verbose way of defining a pandas string series"""
     return pandas.Series([static_str] * len(index)).astype("string")
 
+
 def expand_and_concat_powersets(
     df: pandas.DataFrame, file_path: str, site_name: str
 ) -> pandas.DataFrame:
@@ -120,7 +121,7 @@ def merge_powersets(manager: s3_manager.S3Manager) -> None:
             continue
         latest_metadata = functions.parse_s3_key(latest_path)
         subbucket_path = (
-            f"{manager.study}/{manager.study}__{manager.data_package}/{latest_metadata.site}/" 
+            f"{manager.study}/{manager.study}__{manager.data_package}/{latest_metadata.site}/"
             f"{manager.study}__{manager.data_package}__{manager.version}"
         )
         archives = []
@@ -136,19 +137,17 @@ def merge_powersets(manager: s3_manager.S3Manager) -> None:
                         f"{enums.BucketPath.LAST_VALID.value}/{subbucket_path}/{match_filename}"
                     )
                     archive_target = (
-                        f"{enums.BucketPath.ARCHIVE.value}/{subbucket_path}/{match_timestamped_filename}"
+                        f"{enums.BucketPath.ARCHIVE.value}/{subbucket_path}/"
+                        f"{match_timestamped_filename}"
                     )
-                    manager.move_file(
-                        last_target,
-                        archive_target
-                    )
-                    archives.append((archive_target,last_target))
+                    manager.move_file(last_target, archive_target)
+                    archives.append((archive_target, last_target))
             # otherwise, this is the first instance - after it's in the database,
             # we'll generate a new list of valid tables for the dashboard
             else:
                 is_new_data_package = True
             df = expand_and_concat_powersets(df, latest_path, manager.site)
-            filename=functions.get_s3_filename(latest_path)
+            filename = functions.get_s3_filename(latest_path)
             manager.move_file(
                 f"{enums.BucketPath.LATEST.value}/{subbucket_path}/{filename}",
                 f"{enums.BucketPath.LAST_VALID.value}/{subbucket_path}/{filename}",

--- a/src/site_upload/process_flat/process_flat.py
+++ b/src/site_upload/process_flat/process_flat.py
@@ -3,7 +3,7 @@ import os
 
 import awswrangler
 
-from shared import awswrangler_functions, decorators, enums, functions, pandas_functions, s3_manager
+from shared import decorators, enums, functions, pandas_functions, s3_manager
 
 log_level = os.environ.get("LAMBDA_LOG_LEVEL", "INFO")
 logger = logging.getLogger()
@@ -24,12 +24,6 @@ def process_flat(manager: s3_manager.S3Manager):
     manager.move_file(
         manager.s3_key,
         manager.parquet_flat_key,
-    )
-    awswrangler_functions.generate_csv_from_parquet(
-        manager.s3_bucket_name,
-        manager.parquet_flat_key.split("/", 1)[0],
-        manager.parquet_flat_key.split("/", 1)[1],
-        f"s3://{manager.s3_bucket_name}/{manager.csv_flat_key}",
     )
     df = awswrangler.s3.read_parquet(f"s3://{manager.s3_bucket_name}/{manager.parquet_flat_key}")
     column_dict = pandas_functions.get_column_datatypes(df)

--- a/src/site_upload/study_period/study_period.py
+++ b/src/site_upload/study_period/study_period.py
@@ -25,7 +25,7 @@ def update_study_period(s3_client, s3_bucket, site, study, data_package, version
         for path in paths:
             if latest_path != path:
                 s3_client.delete_object(Bucket=s3_bucket, Key=functions.get_s3_key_from_path(path))
-                paths.remove(path)
+        paths = [latest_path]
     df = awswrangler.s3.read_parquet(paths[0])
     study_meta = functions.read_metadata(
         s3_client, s3_bucket, meta_type=enums.JsonFilename.STUDY_PERIODS.value

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,24 +58,11 @@ def _init_mock_data(s3_client, bucket, study, data_package, version):
         f"{study}__{data_package}__aggregate.parquet",
     )
     s3_client.upload_file(
-        "./tests/test_data/count_synthea_patient_agg.csv",
-        bucket,
-        f"{enums.BucketPath.CSVAGGREGATE.value}/{study}/"
-        f"{study}__{data_package}/{version}/{study}__{data_package}__aggregate.csv",
-    )
-    s3_client.upload_file(
         "./tests/test_data/flat_synthea_q_date_recent.parquet",
         bucket,
         f"{enums.BucketPath.FLAT.value}/{study}/{mock_utils.EXISTING_SITE}/"
         f"{study}__{data_package}__{mock_utils.EXISTING_SITE}__{version}/"
         f"{study}__{data_package}__flat.parquet",
-    )
-    s3_client.upload_file(
-        "./tests/test_data/flat_synthea_q_date_recent.csv",
-        bucket,
-        f"{enums.BucketPath.CSVFLAT.value}/{study}/{mock_utils.EXISTING_SITE}/"
-        f"{study}__{data_package}__{mock_utils.EXISTING_SITE}__{version}/"
-        f"{study}__{data_package}__flat.csv",
     )
     s3_client.upload_file(
         "./tests/test_data/data_packages_cache.json",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,6 +58,13 @@ def _init_mock_data(s3_client, bucket, study, data_package, version):
         f"{study}__{data_package}__aggregate.parquet",
     )
     s3_client.upload_file(
+        "./tests/test_data/meta_date.parquet",
+        bucket,
+        f"{enums.BucketPath.STUDY_META.value}/{study}/"
+        f"{study}__{data_package}/{mock_utils.EXISTING_SITE}/"
+        f"{version}/{study}__meta_date.parquet",
+    )
+    s3_client.upload_file(
         "./tests/test_data/flat_synthea_q_date_recent.parquet",
         bucket,
         f"{enums.BucketPath.FLAT.value}/{study}/{mock_utils.EXISTING_SITE}/"

--- a/tests/mock_utils.py
+++ b/tests/mock_utils.py
@@ -7,7 +7,7 @@ TEST_PROCESS_COUNTS_ARN = "arn:aws:sns:us-east-1:123456789012:test-counts"
 TEST_PROCESS_FLAT_ARN = "arn:aws:sns:us-east-1:123456789012:test-flat"
 TEST_PROCESS_STUDY_META_ARN = "arn:aws:sns:us-east-1:123456789012:test-meta"
 TEST_CACHE_API_ARN = "arn:aws:sns:us-east-1:123456789012:test-cache"
-ITEM_COUNT = 9
+ITEM_COUNT = 11
 DATA_PACKAGE_COUNT = 3
 
 EXISTING_SITE = "princeton_plainsboro_teaching_hospital"

--- a/tests/mock_utils.py
+++ b/tests/mock_utils.py
@@ -7,7 +7,7 @@ TEST_PROCESS_COUNTS_ARN = "arn:aws:sns:us-east-1:123456789012:test-counts"
 TEST_PROCESS_FLAT_ARN = "arn:aws:sns:us-east-1:123456789012:test-flat"
 TEST_PROCESS_STUDY_META_ARN = "arn:aws:sns:us-east-1:123456789012:test-meta"
 TEST_CACHE_API_ARN = "arn:aws:sns:us-east-1:123456789012:test-cache"
-ITEM_COUNT = 13
+ITEM_COUNT = 9
 DATA_PACKAGE_COUNT = 3
 
 EXISTING_SITE = "princeton_plainsboro_teaching_hospital"

--- a/tests/shared/test_awswrangler_functions.py
+++ b/tests/shared/test_awswrangler_functions.py
@@ -1,0 +1,105 @@
+from contextlib import nullcontext as does_not_raise
+
+import pytest
+
+from src.shared import awswrangler_functions, enums
+from tests import mock_utils
+
+AGG_PATH = (
+    "s3://cumulus-aggregator-site-counts-test/aggregates/study/study__encounter/"
+    "study__encounter__099/study__encounter__aggregate.parquet"
+)
+FLAT_PATH = (
+    "s3://cumulus-aggregator-site-counts-test/flat/study/princeton_plainsboro_teaching_hospital/"
+    "study__encounter__princeton_plainsboro_teaching_hospital__099/study__encounter__flat.parquet"
+)
+STUDY_META_PATH = (
+    "s3://cumulus-aggregator-site-counts-test/study_metadata/study/study__encounter/"
+    "princeton_plainsboro_teaching_hospital/099/study__meta_date.parquet"
+)
+
+
+@pytest.mark.parametrize(
+    "root,extension,version,site,expects,raises",
+    [
+        (enums.BucketPath.AGGREGATE.value, "parquet", None, None, [AGG_PATH], does_not_raise()),
+        (
+            enums.BucketPath.AGGREGATE.value,
+            "parquet",
+            f"{mock_utils.EXISTING_STUDY}__{mock_utils.EXISTING_DATA_P}__{mock_utils.EXISTING_VERSION}",
+            None,
+            [AGG_PATH],
+            does_not_raise(),
+        ),
+        (
+            enums.BucketPath.AGGREGATE.value,
+            "parquet",
+            "missing_version",
+            None,
+            [],
+            does_not_raise(),
+        ),
+        (enums.BucketPath.FLAT.value, ".parquet", None, None, [FLAT_PATH], does_not_raise()),
+        (
+            enums.BucketPath.FLAT.value,
+            ".parquet",
+            None,
+            mock_utils.EXISTING_SITE,
+            [FLAT_PATH],
+            does_not_raise(),
+        ),
+        (enums.BucketPath.FLAT.value, ".parquet", None, "missing_site", [], does_not_raise()),
+        (
+            enums.BucketPath.FLAT.value,
+            ".parquet",
+            (
+                f"{mock_utils.EXISTING_STUDY}__{mock_utils.EXISTING_DATA_P}__"
+                f"{mock_utils.EXISTING_SITE}__{mock_utils.EXISTING_VERSION}"
+            ),
+            mock_utils.EXISTING_SITE,
+            [FLAT_PATH],
+            does_not_raise(),
+        ),
+        (
+            enums.BucketPath.FLAT.value,
+            ".parquet",
+            "missing_version",
+            mock_utils.EXISTING_SITE,
+            [],
+            does_not_raise(),
+        ),
+        (enums.BucketPath.AGGREGATE.value, ".doc", None, None, [], does_not_raise()),
+        (
+            "athena",
+            ".parquet",
+            None,
+            None,
+            [],
+            # test path hotmapping for symlinks makes catching the narrow exception fussy
+            pytest.raises(Exception),
+        ),
+    ],
+)
+def test_get_package_list(mock_bucket, root, extension, version, site, expects, raises):
+    with raises:
+        res = awswrangler_functions.get_s3_data_package_list(
+            root,
+            mock_utils.TEST_BUCKET,
+            mock_utils.EXISTING_STUDY,
+            mock_utils.EXISTING_DATA_P,
+            extension=extension,
+            version=version,
+            site=site,
+        )
+        assert res == expects
+
+
+def test_get_s3_study_meta(mock_bucket):
+    res = awswrangler_functions.get_s3_study_meta_list(
+        mock_utils.TEST_BUCKET,
+        mock_utils.EXISTING_STUDY,
+        mock_utils.EXISTING_DATA_P,
+        mock_utils.EXISTING_SITE,
+        mock_utils.EXISTING_VERSION,
+    )
+    assert res == [STUDY_META_PATH]

--- a/tests/shared/test_s3_manager.py
+++ b/tests/shared/test_s3_manager.py
@@ -52,19 +52,10 @@ def test_init_manager(mock_bucket):
         manager.parquet_aggregate_path
         == "s3://cumulus-aggregator-site-counts-test/aggregates/study/study__encounter/study__encounter__099/study__encounter__aggregate.parquet"
     )
-    assert (
-        manager.csv_aggregate_path
-        == "s3://cumulus-aggregator-site-counts-test/csv_aggregates/study/study__encounter/099/study__encounter__aggregate.csv"
-    )
     assert manager.parquet_flat_key == (
         f"flat/study/{mock_utils.EXISTING_SITE}/{mock_utils.EXISTING_STUDY}__{mock_utils.EXISTING_DATA_P}"
         f"__{mock_utils.EXISTING_SITE}__{mock_utils.EXISTING_VERSION}/"
         f"{mock_utils.EXISTING_STUDY}__encounter__{mock_utils.EXISTING_SITE}__flat.parquet"
-    )
-    assert manager.csv_flat_key == (
-        f"csv_flat/study/{mock_utils.EXISTING_SITE}/"
-        f"{mock_utils.EXISTING_STUDY}__{mock_utils.EXISTING_DATA_P}__{mock_utils.EXISTING_SITE}__{mock_utils.EXISTING_VERSION}/"
-        f"{mock_utils.EXISTING_STUDY}__encounter__{mock_utils.EXISTING_SITE}__flat.csv"
     )
 
 
@@ -173,30 +164,6 @@ def test_cache_api(mock_client, mock_bucket):
     assert publish_args["TopicArn"] == mock_utils.TEST_CACHE_API_ARN
     assert publish_args["Message"] == "data_packages"
     assert publish_args["Subject"] == "data_packages"
-
-
-def test_write_csv(mock_bucket):
-    df = pandas.DataFrame(data={"foo": [1, 2], "bar": [11, 22]})
-    manager = s3_manager.S3Manager(
-        mock_sns_event(
-            mock_utils.EXISTING_SITE,
-            mock_utils.EXISTING_STUDY,
-            mock_utils.EXISTING_DATA_P,
-            mock_utils.EXISTING_VERSION,
-        )
-    )
-    manager.write_csv(df)
-    df2 = pandas.read_csv(
-        io.BytesIO(
-            manager.s3_client.get_object(
-                Bucket=manager.s3_bucket_name,
-                Key=(
-                    "csv_aggregates/study/study__encounter/099/" "study__encounter__aggregate.csv"
-                ),
-            )["Body"].read()
-        )
-    )
-    assert df.compare(df2).empty
 
 
 @mock.patch("src.shared.s3_manager.S3Manager.cache_api")

--- a/tests/site_upload/test_powerset_merge.py
+++ b/tests/site_upload/test_powerset_merge.py
@@ -37,7 +37,7 @@ from tests.mock_utils import (
             f"{NEW_STUDY}__{EXISTING_DATA_P}__{EXISTING_VERSION}/encounter.parquet",
             False,
             200,
-            ITEM_COUNT + 4,
+            ITEM_COUNT + 2,
         ),
         (  # Adding a new data package to a site without uploads
             "./tests/test_data/count_synthea_patient.parquet",
@@ -47,7 +47,7 @@ from tests.mock_utils import (
             f"/{NEW_STUDY}__{EXISTING_DATA_P}__{EXISTING_VERSION}/encounter.parquet",
             False,
             200,
-            ITEM_COUNT + 4,
+            ITEM_COUNT + 2,
         ),
         (  # Updating an existing data package
             "./tests/test_data/count_synthea_patient.parquet",
@@ -57,7 +57,7 @@ from tests.mock_utils import (
             f"/{EXISTING_STUDY}__{EXISTING_DATA_P}__{EXISTING_VERSION}/encounter.parquet",
             True,
             200,
-            ITEM_COUNT + 3,
+            ITEM_COUNT + 2,
         ),
         (  # New version of existing data package
             "./tests/test_data/count_synthea_patient.parquet",
@@ -67,7 +67,7 @@ from tests.mock_utils import (
             f"/{EXISTING_STUDY}__{EXISTING_DATA_P}__{NEW_VERSION}/encounter.parquet",
             True,
             200,
-            ITEM_COUNT + 5,
+            ITEM_COUNT + 3,
         ),
         (  # Invalid parquet file
             "./tests/site_upload/test_powerset_merge.py",
@@ -87,7 +87,7 @@ from tests.mock_utils import (
             f"/{NEW_STUDY}__{EXISTING_DATA_P}__{EXISTING_VERSION}/encounter.parquet",
             False,
             200,
-            ITEM_COUNT + 4,
+            ITEM_COUNT + 2,
         ),
         (  # ensuring that a data package that is a substring does not get
             # merged by substr match
@@ -98,7 +98,7 @@ from tests.mock_utils import (
             f"{EXISTING_STUDY}__{EXISTING_DATA_P[0:-2]}__{EXISTING_VERSION}/encount.parquet",
             False,
             200,
-            ITEM_COUNT + 4,
+            ITEM_COUNT + 2,
         ),
         (  # Empty file upload
             None,

--- a/tests/site_upload/test_powerset_merge.py
+++ b/tests/site_upload/test_powerset_merge.py
@@ -265,6 +265,7 @@ def test_powerset_merge_single_upload(
                 or item["Key"].startswith(enums.BucketPath.ADMIN.value)
                 or item["Key"].startswith(enums.BucketPath.CACHE.value)
                 or item["Key"].startswith(enums.BucketPath.FLAT.value)
+                or item["Key"].startswith(enums.BucketPath.STUDY_META.value)
                 or item["Key"].endswith("study_periods.json")
             )
     if archives:
@@ -272,7 +273,7 @@ def test_powerset_merge_single_upload(
         for resource in s3_res["Contents"]:
             keys.append(resource["Key"])
         date_str = datetime.now(UTC).isoformat()
-        archive_path = f".{date_str}.".join(upload_path.split("."))
+        archive_path = f"/{date_str}.".join(upload_path.rsplit("/", 1))
         assert f"{enums.BucketPath.ARCHIVE.value}{archive_path}" in keys
 
 

--- a/tests/site_upload/test_powerset_merge.py
+++ b/tests/site_upload/test_powerset_merge.py
@@ -173,7 +173,7 @@ def test_powerset_merge_single_upload(
             f"{enums.BucketPath.LAST_VALID.value}{upload_path}",
         )
     if duplicates:
-        duplicate_path = upload_path.replace('.parquet','duplicate.parquet')
+        duplicate_path = upload_path.replace(".parquet", "duplicate.parquet")
         s3_client.upload_file(
             upload_file,
             TEST_BUCKET,
@@ -209,8 +209,6 @@ def test_powerset_merge_single_upload(
             if study in item["Key"] and status == 200:
                 agg_df = awswrangler.s3.read_parquet(f"s3://{TEST_BUCKET}/{item['Key']}")
                 assert (agg_df["site"].eq(site)).any()
-        elif item["Key"].endswith("aggregate.csv"):
-            assert item["Key"].startswith(enums.BucketPath.CSVAGGREGATE.value)
         elif item["Key"].endswith("transactions.json"):
             assert item["Key"].startswith(enums.BucketPath.META.value)
             metadata = functions.read_metadata(s3_client, TEST_BUCKET)
@@ -267,7 +265,6 @@ def test_powerset_merge_single_upload(
                 or item["Key"].startswith(enums.BucketPath.ADMIN.value)
                 or item["Key"].startswith(enums.BucketPath.CACHE.value)
                 or item["Key"].startswith(enums.BucketPath.FLAT.value)
-                or item["Key"].startswith(enums.BucketPath.CSVFLAT.value)
                 or item["Key"].endswith("study_periods.json")
             )
     if archives:

--- a/tests/site_upload/test_process_upload.py
+++ b/tests/site_upload/test_process_upload.py
@@ -152,8 +152,6 @@ def test_process_upload(
     for item in s3_res["Contents"]:
         if item["Key"].endswith("aggregate.parquet"):
             assert item["Key"].startswith(enums.BucketPath.AGGREGATE.value)
-        elif item["Key"].endswith("aggregate.csv"):
-            assert item["Key"].startswith(enums.BucketPath.CSVAGGREGATE.value)
         elif item["Key"].endswith("transactions.json"):
             assert item["Key"].startswith(enums.BucketPath.META.value)
             if upload_path is not None and "template" not in upload_path:
@@ -178,7 +176,6 @@ def test_process_upload(
                 or item["Key"].startswith(enums.BucketPath.ADMIN.value)
                 or item["Key"].startswith(enums.BucketPath.CACHE.value)
                 or item["Key"].startswith(enums.BucketPath.FLAT.value)
-                or item["Key"].startswith(enums.BucketPath.CSVFLAT.value)
                 or item["Key"].startswith(enums.BucketPath.ARCHIVE.value)
                 or item["Key"].endswith("study_periods.json")
                 or item["Key"].endswith("column_types.json")

--- a/tests/site_upload/test_process_upload.py
+++ b/tests/site_upload/test_process_upload.py
@@ -94,11 +94,11 @@ from tests.mock_utils import (
             "./tests/test_data/cube_simple_example.parquet",
             (
                 f"/{EXISTING_STUDY}/{EXISTING_DATA_P}/{EXISTING_SITE}/"
-                f"{EXISTING_VERSION}/document_meta_date.parquet"
+                f"{EXISTING_VERSION}/document__meta_date.parquet"
             ),
             (
                 f"/{EXISTING_STUDY}/{EXISTING_DATA_P}/{EXISTING_SITE}/"
-                f"{EXISTING_VERSION}/document_meta_date.parquet"
+                f"{EXISTING_VERSION}/document__meta_date.parquet"
             ),
             200,
             ITEM_COUNT + 1,
@@ -177,6 +177,7 @@ def test_process_upload(
                 or item["Key"].startswith(enums.BucketPath.CACHE.value)
                 or item["Key"].startswith(enums.BucketPath.FLAT.value)
                 or item["Key"].startswith(enums.BucketPath.ARCHIVE.value)
+                or item["Key"].startswith(enums.BucketPath.STUDY_META.value)
                 or item["Key"].endswith("study_periods.json")
                 or item["Key"].endswith("column_types.json")
             )

--- a/tests/site_upload/test_study_period.py
+++ b/tests/site_upload/test_study_period.py
@@ -118,6 +118,17 @@ def test_process_upload(
     mock_bucket,
 ):
     s3_client = boto3.client("s3", region_name="us-east-1")
+    # we'll get rid of the fixture data in study_meta because we care
+    # about timestamps in this case
+    # TODO - consider having a intermediate position for files to land so
+    # we don't have to do timestamp processing
+    s3_client.delete_object(
+        Bucket=TEST_BUCKET,
+        Key=(
+            "study_metadata/study/study__encounter/princeton_plainsboro_teaching_hospital/"
+            "099/study__meta_date.parquet"
+        ),
+    )
     if multiple_files:
         s3_client.upload_file(
             upload_file,


### PR DESCRIPTION
Broken up into three commits for my own sanity/testing isolation:
Commit one: 
 - Removes CSV generation, and updates infrastructure to not care about csv paths/not expect csvs during tests
 - Adds a migration for cleaning up buckets
Commit two:
 - Changes how archiving works during powerset merge to archive everything in a folder, rather than expecting a filename pattern
 Commit three:
 - Removes the CSV enums, and also some ruff formatting on push (probably fine to skim for review