### PR TITLE
Updated source for latest path location

### DIFF
--- a/src/site_upload/powerset_merge/powerset_merge.py
+++ b/src/site_upload/powerset_merge/powerset_merge.py
@@ -145,7 +145,7 @@ def merge_powersets(manager: s3_manager.S3Manager) -> None:
             df = expand_and_concat_powersets(df, latest_path, manager.site)
             filename = functions.get_filename_from_s3_path(latest_path)
             manager.move_file(
-                f"{enums.BucketPath.LATEST.value}/{subbucket_path}/{filename}",
+                functions.get_s3_key_from_path(latest_path),
                 f"{enums.BucketPath.LAST_VALID.value}/{subbucket_path}/{filename}",
             )
 


### PR DESCRIPTION
Since subbucket path does not exactly match the latest path, get the key directly from the path returned from the object list.