### PR TITLE
Coerce datetime indexes to dates

### DIFF
--- a/src/dashboard/get_chart_data/get_chart_data.py
+++ b/src/dashboard/get_chart_data/get_chart_data.py
@@ -225,6 +225,17 @@ def _format_payload(
         payload["counts"] = counts.to_dict()[(count_col, "sum")]
 
         data = []
+        # When we start trying to create a multiindex dataframe here,
+        # timestamp values get propogated into that index with timestamps,
+        # so they don't line up with our date level columns. So we'll
+        # convert these columns to strings, assuming that for our use case,
+        # we'll never want timestamps.
+
+        # If this assumption proves false later, we could try to look for date
+        # signifiers in column names instead?
+        for column in [query_params["column"], query_params["stratifier"]]:
+            if pandas.api.types.is_datetime64_ns_dtype(df.dtypes[column]):
+                df[column] = df[column].dt.strftime("%Y-%m-%d")
         stratifiers = df[query_params["stratifier"]].unique()
         df = df.groupby([query_params["stratifier"], query_params["column"]]).agg(
             {count_col: ["sum"]}

--- a/tests/dashboard/test_get_chart_data.py
+++ b/tests/dashboard/test_get_chart_data.py
@@ -52,6 +52,21 @@ def test_format_payload(query_params, filter_groups, expected_payload):
     assert payload == expected_payload
 
 
+def test_format_payload_date_coercion():
+    df = pandas.DataFrame(
+        {
+            "a": ["C", "D"],
+            "b": [
+                pandas.to_datetime("2020-01-01 00:00:00"),
+                pandas.to_datetime("2020-01-01 00:00:00"),
+            ],
+            "cnt": [20, 15],
+        }
+    )
+    payload = get_chart_data._format_payload(df, {"column": "a", "stratifier": "b"}, [], "cnt")
+    assert payload["data"] == [{"stratifier": "2020-01-01", "rows": [["C", 20], ["D", 15]]}]
+
+
 def test_get_data_cols(mock_bucket):
     table_id = f"{EXISTING_STUDY}__{EXISTING_DATA_P}__{EXISTING_VERSION}"
     res = get_chart_data._get_table_cols(table_id)


### PR DESCRIPTION
Datetimes as indexes don't respect date formatting well, so when retrieving the data for the dashboard, we'll cast them to date strings instead.