### PR TITLE
Remove all previous files when a new flat file is uploaded

### DIFF
--- a/src/site_upload/process_flat/process_flat.py
+++ b/src/site_upload/process_flat/process_flat.py
@@ -11,15 +11,13 @@ logger.setLevel(log_level)
 
 
 def process_flat(manager: s3_manager.S3Manager):
-    if awswrangler.s3.does_object_exist(
-        f"s3://{manager.s3_bucket_name}/{manager.parquet_flat_key}"
-    ):
-        manager.move_file(
-            manager.parquet_flat_key,
-            manager.parquet_flat_key.replace(
-                enums.BucketPath.FLAT.value, enums.BucketPath.ARCHIVE.value
-            ),
-        )
+    flat_path = manager.parquet_flat_key[:-1]
+    for key in manager.get_data_package_list(enums.BucketPath.FLAT.value):
+        if flat_path in key:
+            manager.move_file(
+                key,
+                key.replace(enums.BucketPath.FLAT.value, enums.BucketPath.ARCHIVE.value),
+            )
 
     manager.move_file(
         manager.s3_key,

--- a/src/site_upload/process_flat/process_flat.py
+++ b/src/site_upload/process_flat/process_flat.py
@@ -11,9 +11,9 @@ logger.setLevel(log_level)
 
 
 def process_flat(manager: s3_manager.S3Manager):
-    flat_path = manager.parquet_flat_key[:-1]
+    flat_path = manager.parquet_flat_key.rsplit("/", 1)[0]
     for key in manager.get_data_package_list(enums.BucketPath.FLAT.value):
-        if flat_path in key:
+        if functions.get_s3_key_from_path(key).startswith(flat_path):
             manager.move_file(
                 key,
                 key.replace(enums.BucketPath.FLAT.value, enums.BucketPath.ARCHIVE.value),

--- a/tests/site_upload/test_process_flat.py
+++ b/tests/site_upload/test_process_flat.py
@@ -14,7 +14,10 @@ def test_process_flat(mock_cache, mock_bucket):
                 "Sns": {
                     "TopicArn": "arn",
                     "Message": (
-                        "latest/study/study__encounter/site/study__encounter__site__version/file.parquet"
+                        f"latest/{mock_utils.EXISTING_STUDY}/{mock_utils.EXISTING_STUDY}__"
+                        f"{mock_utils.EXISTING_DATA_P}/{mock_utils.EXISTING_SITE}/"
+                        f"{mock_utils.EXISTING_STUDY}__{mock_utils.EXISTING_DATA_P}__"
+                        f"{mock_utils.EXISTING_SITE}__{mock_utils.EXISTING_VERSION}/file.parquet"
                     ),
                 }
             }
@@ -34,7 +37,10 @@ def test_process_flat(mock_cache, mock_bucket):
         file["Key"] for file in s3_client.list_objects_v2(Bucket=mock_utils.TEST_BUCKET)["Contents"]
     ]
     assert (
-        "flat/study/site/study__encounter__site__version/" "study__encounter__site__flat.parquet"
+        f"flat/{mock_utils.EXISTING_STUDY}/{mock_utils.EXISTING_SITE}/"
+        f"{mock_utils.EXISTING_STUDY}__{mock_utils.EXISTING_DATA_P}__{mock_utils.EXISTING_SITE}"
+        f"__{mock_utils.EXISTING_VERSION}/"
+        f"{mock_utils.EXISTING_STUDY}__{mock_utils.EXISTING_DATA_P}__{mock_utils.EXISTING_SITE}__flat.parquet"
     ) in files
 
     mock_cache.reset_mock()


### PR DESCRIPTION
In case the format of the flat destination changes, we'll remove all matching files for a given flat data package in a previous upload.