### PR TITLE
Added integration test, bugfixes for chart data and flat packages

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 default_install_hook_types: [pre-commit, pre-push]
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.6
+    rev: v0.11.11
     hooks:
       - name: Ruff linting
         id: ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ test = [
 dev = [
     "duckdb",
     "pre-commit",
-    "ruff < 0.9",
+    "ruff > 0.11, <0.12",
     "sqlfluff >= 3.2.5"
 ]
 

--- a/scripts/cumulus_upload_data.py
+++ b/scripts/cumulus_upload_data.py
@@ -65,9 +65,7 @@ def upload_file(cli_args):
         http_response = requests.post(body["url"], data=body["fields"], files=files, timeout=60)
 
     # If successful, returns HTTP status code 204
-    print(
-        f"{cli_args['user']}_{object_name} upload HTTP status code: " f"{http_response.status_code}"
-    )
+    print(f"{cli_args['user']}_{object_name} upload HTTP status code: {http_response.status_code}")
 
 
 if __name__ == "__main__":
@@ -100,8 +98,7 @@ if __name__ == "__main__":
     if args["test"]:
         args_dict["user"] = os.environ.get("CUMULUS_TEST_UPLOAD_USER", "general")
         args_dict["file"] = (
-            f"{Path(__file__).resolve().parents[1]!s}"
-            f"/tests/test_data/count_synthea_patient.parquet"
+            f"{Path(__file__).resolve().parents[1]!s}/tests/test_data/count_synthea_patient.parquet"
         )
         args_dict["auth"] = os.environ.get("CUMULUS_TEST_UPLOAD_AUTH", "secretval")
         args_dict["study"] = "core"

--- a/scripts/reset_data_package_cache.py
+++ b/scripts/reset_data_package_cache.py
@@ -71,22 +71,14 @@ def get_s3_json_as_dict(bucket, key: str):
     return json.loads(bytes_buffer.getvalue().decode())
 
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
-        description="""Creates data package metadata for existing aggregates. """
-    )
-    parser.add_argument("-b", "--bucket", help="bucket name")
-    parser.add_argument("-d", "--db", help="database name")
-    args = parser.parse_args()
+def reset_data_package_cache(bucket, db):
     s3_client = boto3.client("s3")
-    update_column_type_metadata(args.bucket, s3_client)
+    update_column_type_metadata(bucket, s3_client)
     env_cache = dict(os.environ)
     try:
         # mock some env vars assumed to be set inside a lambda env
-        os.environ["BUCKET_NAME"] = args.bucket
-        cache_api.cache_api_data(
-            s3_client, args.bucket, args.db, enums.JsonFilename.DATA_PACKAGES.value
-        )
+        os.environ["BUCKET_NAME"] = bucket
+        cache_api.cache_api_data(s3_client, bucket, db, enums.JsonFilename.DATA_PACKAGES.value)
     except AttributeError as e:
         print(e)
         print("".join(traceback.format_exception(e)))
@@ -97,3 +89,13 @@ if __name__ == "__main__":
     finally:
         os.environ.clear()
         os.environ.update(env_cache)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="""Creates data package metadata for existing aggregates. """
+    )
+    parser.add_argument("-b", "--bucket", help="bucket name")
+    parser.add_argument("-d", "--db", help="database name")
+    args = parser.parse_args()
+    reset_data_package_cache(args.bucket, args.db)

--- a/src/dashboard/get_chart_data/get_chart_data.py
+++ b/src/dashboard/get_chart_data/get_chart_data.py
@@ -226,10 +226,15 @@ def _format_payload(
 
         data = []
 
-        # We're trying to smooth over a couple of representation level issues
-        # that are normally smoothed over by the pandas output tooling, as
-        # a byproduct of squashing data into a multiindex, which strips out
-        # some context. Notably we're trying to hit the following cases:
+        # We are combining two values into a pandas index. This means that we've got
+        # two different ways the data is represented:
+        # 1. in the dataframe itself, where pandas does some intelligent things
+        #   about how the data is represented (for example, truncating python
+        #   datetimes to dates if they are all have a timestamp of zero)
+        # 2. the string representation of the underlying numpy data type converted
+        #   to a string, which in this case is the full datetime representation
+        # So, we're going to adjust the values in the multiindex to match the
+        # values in the dataframe itself, fixing the following kinds of issues:
         # - dates getting encoded as timestamps
         # - numerics becoming objects, when we expect them to be string-like
         #   after adding `cumulus_none`

--- a/src/dashboard/get_from_parquet/get_from_parquet.py
+++ b/src/dashboard/get_from_parquet/get_from_parquet.py
@@ -32,7 +32,7 @@ def from_parquet_handler(event, context):
             extra_headers={
                 "Content-Type": "text/csv",
                 "Content-disposition": (
-                    f"attachment; filename={s3_path.split('/')[-1].replace('.parquet','.csv')}"
+                    f"attachment; filename={s3_path.split('/')[-1].replace('.parquet', '.csv')}"
                 ),
                 "Content-Length": len(payload.encode("UTF-8")),
             },

--- a/src/dashboard/post_distribute/post_distribute.py
+++ b/src/dashboard/post_distribute/post_distribute.py
@@ -25,7 +25,7 @@ def validate_github_url(config):
     if res.status_code != 200:
         raise ValueError(f"{config['url']} is not a valid git repository")
     if "tag" in config and config["tag"] is not None:
-        res = requests.get(config["url"] + f'/tree/{config["tag"]}', timeout=10)
+        res = requests.get(config["url"] + f"/tree/{config['tag']}", timeout=10)
         if res.status_code != 200:
             raise ValueError(f"{config['tag']} is not a valid tag")
 
@@ -51,5 +51,5 @@ def distribute_handler(event: dict, context):
     topic_sns_arn = os.environ.get("TOPIC_QUEUE_API_ARN")
     sns_client.publish(TopicArn=topic_sns_arn, Message=event["body"], Subject=body["study_name"])
     # TODO: should we create an ID/API for the dashboard to track request status?
-    res = functions.http_response(200, f'Preparing to queue {body["study_name"]}.')
+    res = functions.http_response(200, f"Preparing to queue {body['study_name']}.")
     return res

--- a/src/dashboard/queue_distribute/queue_distribute.py
+++ b/src/dashboard/queue_distribute/queue_distribute.py
@@ -92,5 +92,5 @@ def queue_handler(event: dict, context):
             Subject=body["study_name"],
             MessageAttributes={"study": {"DataType": "Binary", "BinaryValue": file}},
         )
-    res = functions.http_response(200, f'Study {body["study_name"]} queued.')
+    res = functions.http_response(200, f"Study {body['study_name']} queued.")
     return res

--- a/src/shared/decorators.py
+++ b/src/shared/decorators.py
@@ -27,7 +27,7 @@ def generic_error_handler(msg="Internal server error"):
                     )
                     tb = tb.tb_next
                 logging.error(
-                    "Error: %s, type: %s, event: %s, " "context: %s, file: %s, traceback: %s",
+                    "Error: %s, type: %s, event: %s, context: %s, file: %s, traceback: %s",
                     msg,
                     str(e),
                     args[0],

--- a/src/shared/functions.py
+++ b/src/shared/functions.py
@@ -116,8 +116,8 @@ def update_metadata(
     """
     if extra_items is None:
         extra_items = {}
-    check_meta_type(meta_type)
 
+    check_meta_type(meta_type)
     match meta_type:
         case enums.JsonFilename.TRANSACTIONS.value:
             site_metadata = metadata.setdefault(site, {})

--- a/src/shared/s3_manager.py
+++ b/src/shared/s3_manager.py
@@ -183,6 +183,10 @@ class S3Manager:
             or extra_items.get("type", "") == "flat"
         ):
             site = self.site
+        if extra_items.get("type", "") == "flat":
+            version = f"{self.study}__{self.data_package}__{self.site}__{self.version}"
+        else:
+            version = f"{self.study}__{self.data_package}__{self.version}"
         if metadata is None:
             metadata = self.metadata
         functions.update_metadata(
@@ -190,7 +194,7 @@ class S3Manager:
             site=site,
             study=self.study,
             data_package=self.data_package,
-            version=self.version,
+            version=version,
             target=key,
             value=value,
             meta_type=meta_type,

--- a/src/site_upload/process_flat/process_flat.py
+++ b/src/site_upload/process_flat/process_flat.py
@@ -38,7 +38,11 @@ def process_flat(manager: s3_manager.S3Manager):
         meta_type=enums.JsonFilename.COLUMN_TYPES.value,
         extra_items=extras,
     )
-    manager.update_local_metadata(enums.TransactionKeys.LAST_DATA_UPDATE.value, site=manager.site)
+    manager.update_local_metadata(
+        enums.TransactionKeys.LAST_DATA_UPDATE.value,
+        site=manager.site,
+        extra_items=extras,
+    )
     manager.update_local_metadata(
         enums.ColumnTypesKeys.LAST_DATA_UPDATE.value,
         value=column_dict,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,8 +68,8 @@ def _init_mock_data(s3_client, bucket, study, data_package, version):
         "./tests/test_data/flat_synthea_q_date_recent.parquet",
         bucket,
         f"{enums.BucketPath.FLAT.value}/{study}/{mock_utils.EXISTING_SITE}/"
-        f"{study}__{data_package}__{mock_utils.EXISTING_SITE}__{version}/"
-        f"{study}__{data_package}__flat.parquet",
+        f"{study}__c_{data_package}__{mock_utils.EXISTING_SITE}__{version}/"
+        f"{study}__c_{data_package}__flat.parquet",
     )
     s3_client.upload_file(
         "./tests/test_data/data_packages_cache.json",

--- a/tests/mock_utils.py
+++ b/tests/mock_utils.py
@@ -17,8 +17,9 @@ NEW_STUDY = "new_study"
 EXISTING_STUDY = "study"
 OTHER_STUDY = "other_study"
 EXISTING_DATA_P = "encounter"
-EXISTING_FLAT_DATA_P = "c_encounter"
 NEW_DATA_P = "document"
+EXISTING_FLAT_DATA_P = "c_encounter"
+NEW_FLAT_DATA_P = "c_document"
 EXISTING_VERSION = "099"
 NEW_VERSION = "100"
 
@@ -128,13 +129,15 @@ def get_mock_column_types_metadata():
         EXISTING_STUDY: {
             EXISTING_DATA_P: {
                 f"{EXISTING_STUDY}__{EXISTING_DATA_P}__{EXISTING_VERSION}": {
-                    "column_types_format_version": "2",
+                    "column_types_format_version": "3",
                     "columns": {
-                        "cnt": "integer",
-                        "gender": "string",
-                        "age": "integer",
-                        "race_display": "string",
-                        "site": "string",
+                        "cnt": {
+                            "type": "integer",
+                        },
+                        "gender": {"type": "string", "distinct_values_count": 10},
+                        "age": {"type": "integer", "distinct_values_count": 10},
+                        "race_display": {"type": "string", "distinct_values_count": 10},
+                        "site": {"type": "string", "distinct_values_count": 10},
                     },
                     "last_data_update": "2023-02-24T15:08:07.771080+00:00",
                     "s3_path": (
@@ -145,41 +148,54 @@ def get_mock_column_types_metadata():
                     "total": 1000,
                     "id": f"{EXISTING_STUDY}__{EXISTING_DATA_P}__{EXISTING_VERSION}",
                 },
-                EXISTING_FLAT_DATA_P: {
-                    f"{EXISTING_STUDY}__{EXISTING_FLAT_DATA_P}__{EXISTING_VERSION}": {
-                        "column_types_format_version": "2",
-                        "columns": {
-                            "resource": "string",
-                            "subgroup": "string",
-                            "numerator": "integer",
-                            "denominator": "double",
-                            "percentage": "double",
+            },
+            f"{EXISTING_FLAT_DATA_P}__{EXISTING_SITE}": {
+                f"{EXISTING_STUDY}__{EXISTING_FLAT_DATA_P}__{EXISTING_SITE}__{EXISTING_VERSION}": {
+                    "column_types_format_version": "3",
+                    "columns": {
+                        "resource": {
+                            "type": "string",
                         },
-                        "last_data_update": "2023-02-24T15:08:07.771080+00:00",
-                        "s3_path": (
-                            f"aggregates/{EXISTING_STUDY}/{EXISTING_STUDY}__{EXISTING_FLAT_DATA_P}/"
-                            f"{EXISTING_STUDY}__{EXISTING_FLAT_DATA_P}__{EXISTING_VERSION}/"
-                            f"{EXISTING_STUDY}__{EXISTING_FLAT_DATA_P}__flat.parquet"
-                        ),
-                        "site": EXISTING_SITE,
-                        "id": (
-                            f"{EXISTING_STUDY}__{EXISTING_FLAT_DATA_P}__"
-                            f"{EXISTING_VERSION}__{EXISTING_SITE}"
-                        ),
+                        "subgroup": {
+                            "type": "string",
+                        },
+                        "numerator": {
+                            "type": "integer",
+                        },
+                        "denominator": {
+                            "type": "double",
+                        },
+                        "percentage": {
+                            "type": "double",
+                        },
                     },
+                    "last_data_update": "2023-02-24T15:08:07.771080+00:00",
+                    "s3_path": (
+                        f"flat/{EXISTING_STUDY}/{EXISTING_SITE}/"
+                        f"{EXISTING_STUDY}__{EXISTING_FLAT_DATA_P}__{EXISTING_SITE}__{EXISTING_VERSION}/"
+                        f"{EXISTING_STUDY}__{EXISTING_FLAT_DATA_P}__flat.parquet"
+                    ),
+                    "site": EXISTING_SITE,
+                    "id": (
+                        f"{EXISTING_STUDY}__{EXISTING_FLAT_DATA_P}__"
+                        f"{EXISTING_VERSION}__{EXISTING_SITE}"
+                    ),
+                    "type": "flat",
                 },
-            }
+            },
         },
         OTHER_STUDY: {
             EXISTING_DATA_P: {
                 f"{OTHER_STUDY}__{EXISTING_DATA_P}__{EXISTING_VERSION}": {
-                    "column_types_format_version": "2",
+                    "column_types_format_version": "3",
                     "columns": {
-                        "cnt": "integer",
-                        "gender": "string",
-                        "age": "integer",
-                        "race_display": "string",
-                        "site": "string",
+                        "cnt": {
+                            "type": "integer",
+                        },
+                        "gender": {"type": "string", "distinct_values_count": 10},
+                        "age": {"type": "integer", "distinct_values_count": 10},
+                        "race_display": {"type": "string", "distinct_values_count": 10},
+                        "site": {"type": "string", "distinct_values_count": 10},
                     },
                     "last_data_update": "2023-02-24T15:08:07.771080+00:00",
                     "s3_path": (
@@ -190,7 +206,41 @@ def get_mock_column_types_metadata():
                     "total": 2000,
                     "id": f"{OTHER_STUDY}__{EXISTING_DATA_P}__{EXISTING_VERSION}/",
                 }
-            }
+            },
+            f"{EXISTING_FLAT_DATA_P}__{EXISTING_SITE}": {
+                f"{OTHER_STUDY}__{EXISTING_FLAT_DATA_P}__{EXISTING_SITE}__{EXISTING_VERSION}": {
+                    "column_types_format_version": "3",
+                    "columns": {
+                        "resource": {
+                            "type": "string",
+                        },
+                        "subgroup": {
+                            "type": "string",
+                        },
+                        "numerator": {
+                            "type": "integer",
+                        },
+                        "denominator": {
+                            "type": "double",
+                        },
+                        "percentage": {
+                            "type": "double",
+                        },
+                    },
+                    "last_data_update": "2023-02-24T15:08:07.771080+00:00",
+                    "s3_path": (
+                        f"flat/{OTHER_STUDY}/{EXISTING_SITE}/"
+                        f"{OTHER_STUDY}__{EXISTING_FLAT_DATA_P}__{EXISTING_SITE}__{EXISTING_VERSION}/"
+                        f"{OTHER_STUDY}__{EXISTING_FLAT_DATA_P}__flat.parquet"
+                    ),
+                    "site": EXISTING_SITE,
+                    "id": (
+                        f"{OTHER_STUDY}__{EXISTING_FLAT_DATA_P}__"
+                        f"{EXISTING_VERSION}__{EXISTING_SITE}"
+                    ),
+                    "type": "flat",
+                },
+            },
         },
     }
 

--- a/tests/shared/test_awswrangler_functions.py
+++ b/tests/shared/test_awswrangler_functions.py
@@ -11,7 +11,7 @@ AGG_PATH = (
 )
 FLAT_PATH = (
     "s3://cumulus-aggregator-site-counts-test/flat/study/princeton_plainsboro_teaching_hospital/"
-    "study__encounter__princeton_plainsboro_teaching_hospital__099/study__encounter__flat.parquet"
+    "study__c_encounter__princeton_plainsboro_teaching_hospital__099/study__c_encounter__flat.parquet"
 )
 STUDY_META_PATH = (
     "s3://cumulus-aggregator-site-counts-test/study_metadata/study/study__encounter/"
@@ -20,14 +20,23 @@ STUDY_META_PATH = (
 
 
 @pytest.mark.parametrize(
-    "root,extension,version,site,expects,raises",
+    "root,extension,version,site,dp,expects,raises",
     [
-        (enums.BucketPath.AGGREGATE.value, "parquet", None, None, [AGG_PATH], does_not_raise()),
+        (
+            enums.BucketPath.AGGREGATE.value,
+            "parquet",
+            None,
+            None,
+            mock_utils.EXISTING_DATA_P,
+            [AGG_PATH],
+            does_not_raise(),
+        ),
         (
             enums.BucketPath.AGGREGATE.value,
             "parquet",
             f"{mock_utils.EXISTING_STUDY}__{mock_utils.EXISTING_DATA_P}__{mock_utils.EXISTING_VERSION}",
             None,
+            mock_utils.EXISTING_DATA_P,
             [AGG_PATH],
             does_not_raise(),
         ),
@@ -36,27 +45,46 @@ STUDY_META_PATH = (
             "parquet",
             "missing_version",
             None,
+            mock_utils.EXISTING_DATA_P,
             [],
             does_not_raise(),
         ),
-        (enums.BucketPath.FLAT.value, ".parquet", None, None, [FLAT_PATH], does_not_raise()),
+        (
+            enums.BucketPath.FLAT.value,
+            ".parquet",
+            None,
+            None,
+            mock_utils.EXISTING_FLAT_DATA_P,
+            [FLAT_PATH],
+            does_not_raise(),
+        ),
         (
             enums.BucketPath.FLAT.value,
             ".parquet",
             None,
             mock_utils.EXISTING_SITE,
+            mock_utils.EXISTING_FLAT_DATA_P,
             [FLAT_PATH],
             does_not_raise(),
         ),
-        (enums.BucketPath.FLAT.value, ".parquet", None, "missing_site", [], does_not_raise()),
+        (
+            enums.BucketPath.FLAT.value,
+            ".parquet",
+            None,
+            "missing_site",
+            mock_utils.EXISTING_DATA_P,
+            [],
+            does_not_raise(),
+        ),
         (
             enums.BucketPath.FLAT.value,
             ".parquet",
             (
-                f"{mock_utils.EXISTING_STUDY}__{mock_utils.EXISTING_DATA_P}__"
+                f"{mock_utils.EXISTING_STUDY}__{mock_utils.EXISTING_FLAT_DATA_P}__"
                 f"{mock_utils.EXISTING_SITE}__{mock_utils.EXISTING_VERSION}"
             ),
             mock_utils.EXISTING_SITE,
+            mock_utils.EXISTING_FLAT_DATA_P,
             [FLAT_PATH],
             does_not_raise(),
         ),
@@ -65,28 +93,38 @@ STUDY_META_PATH = (
             ".parquet",
             "missing_version",
             mock_utils.EXISTING_SITE,
+            mock_utils.EXISTING_FLAT_DATA_P,
             [],
             does_not_raise(),
         ),
-        (enums.BucketPath.AGGREGATE.value, ".doc", None, None, [], does_not_raise()),
+        (
+            enums.BucketPath.AGGREGATE.value,
+            ".doc",
+            None,
+            None,
+            mock_utils.EXISTING_DATA_P,
+            [],
+            does_not_raise(),
+        ),
         (
             "athena",
             ".parquet",
             None,
             None,
+            mock_utils.EXISTING_DATA_P,
             [],
             # test path hotmapping for symlinks makes catching the narrow exception fussy
             pytest.raises(Exception),
         ),
     ],
 )
-def test_get_package_list(mock_bucket, root, extension, version, site, expects, raises):
+def test_get_package_list(mock_bucket, root, extension, version, site, dp, expects, raises):
     with raises:
         res = awswrangler_functions.get_s3_data_package_list(
             root,
             mock_utils.TEST_BUCKET,
             mock_utils.EXISTING_STUDY,
-            mock_utils.EXISTING_DATA_P,
+            dp,
             extension=extension,
             version=version,
             site=site,

--- a/tests/shared/test_s3_manager.py
+++ b/tests/shared/test_s3_manager.py
@@ -319,6 +319,7 @@ def test_write_parquet(mock_cache, mock_bucket):
 def test_update_local_metadata(
     mock_bucket, site, study, data_package, version, metadata_type, target, extras
 ):
+    dp_id = f"{study}__{data_package}__{version}"
     manager = s3_manager.S3Manager(mock_sns_event(site, study, data_package, version))
     if metadata_type == enums.JsonFilename.COLUMN_TYPES.value:
         metadata = manager.types_metadata
@@ -347,18 +348,18 @@ def test_update_local_metadata(
         assert original_transactions != manager.metadata
     if metadata_type == enums.JsonFilename.COLUMN_TYPES.value:
         assert study in metadata.keys()
-        assert version in metadata[study][data_package].keys()
+        assert dp_id in metadata[study][data_package].keys()
         for extra in extras:
-            assert extra in metadata[study][data_package][version].keys()
+            assert extra in metadata[study][data_package][dp_id].keys()
         if target == "columns":
-            assert metadata[study][data_package][version]["columns"] == mock_columns
+            assert metadata[study][data_package][dp_id]["columns"] == mock_columns
         else:
-            assert metadata[study][data_package][version]["columns"] != mock_columns
+            assert metadata[study][data_package][dp_id]["columns"] != mock_columns
     elif metadata_type == enums.JsonFilename.TRANSACTIONS.value:
         assert site in metadata.keys()
-        assert version in metadata[site][study][data_package].keys()
+        assert dp_id in metadata[site][study][data_package].keys()
         for extra in extras:
-            assert extra in metadata[site][study][data_package][version].keys()
+            assert extra in metadata[site][study][data_package][dp_id].keys()
 
 
 def test_write_local_metadata(mock_bucket):

--- a/tests/site_upload/test_cache_api.py
+++ b/tests/site_upload/test_cache_api.py
@@ -64,21 +64,20 @@ def test_cache_api_data(mock_bucket):
         {
             "study": "study",
             "name": "encounter",
-            "column_types_format_version": "2",
+            "column_types_format_version": "3",
             "columns": {
-                "cnt": "integer",
-                "gender": "string",
-                "age": "integer",
-                "race_display": "string",
-                "site": "string",
+                "cnt": {"type": "integer"},
+                "gender": {"type": "string", "distinct_values_count": 10},
+                "age": {"type": "integer", "distinct_values_count": 10},
+                "race_display": {"type": "string", "distinct_values_count": 10},
+                "site": {"type": "string", "distinct_values_count": 10},
             },
             "last_data_update": "2023-02-24T15:08:07.771080+00:00",
             "s3_path": (
-                "aggregates/study/study__encounter/study__encounter__099"
-                "/study__encounter__aggregate.parquet"
+                "aggregates/study/study__encounter/study__encounter__099/study__encounter__aggregate.parquet"
             ),
             "total": 1000,
-            "version": "099",
             "id": "study__encounter__099",
+            "version": "099",
         }
     ]

--- a/tests/site_upload/test_powerset_merge.py
+++ b/tests/site_upload/test_powerset_merge.py
@@ -191,12 +191,13 @@ def test_powerset_merge_single_upload(
         ]
     }
     # This array looks like:
-    # ['', 'study', 'package', 'site', 'package_id','file']
+    # ['', 'study', 'study__package', 'site', 'version','file']
     event_list = event_key.split("/")
     study = event_list[1]
     data_package = event_list[2]
     site = event_list[3]
     version = event_list[4]
+    dp_id = f"{data_package}__{version}"
     res = powerset_merge.powerset_merge_handler(event, {})
     assert res["statusCode"] == status
     s3_res = s3_client.list_objects_v2(Bucket=TEST_BUCKET)
@@ -213,7 +214,7 @@ def test_powerset_merge_single_upload(
             metadata = functions.read_metadata(s3_client, TEST_BUCKET)
             if res["statusCode"] == 200:
                 assert (
-                    metadata[site][study][data_package.split("__")[1]][version]["last_aggregation"]
+                    metadata[site][study][data_package.split("__")[1]][dp_id]["last_aggregation"]
                     == datetime.now(UTC).isoformat()
                 )
 
@@ -229,7 +230,7 @@ def test_powerset_merge_single_upload(
             if upload_file is not None and study != NEW_STUDY:
                 # checking to see that merge powerset didn't touch last upload
                 assert (
-                    metadata[site][study][data_package.split("__")[1]][version]["last_upload"]
+                    metadata[site][study][data_package.split("__")[1]][dp_id]["last_upload"]
                     != datetime.now(UTC).isoformat()
                 )
         elif item["Key"].endswith("column_types.json"):
@@ -238,7 +239,7 @@ def test_powerset_merge_single_upload(
                 s3_client, TEST_BUCKET, meta_type=enums.JsonFilename.COLUMN_TYPES.value
             )
             if res["statusCode"] == 200:
-                last_update = metadata[study][data_package.split("__")[1]][version][
+                last_update = metadata[study][data_package.split("__")[1]][dp_id][
                     "last_data_update"
                 ]
                 assert last_update == datetime.now(UTC).isoformat()

--- a/tests/site_upload/test_powerset_merge.py
+++ b/tests/site_upload/test_powerset_merge.py
@@ -255,9 +255,9 @@ def test_powerset_merge_single_upload(
             if item["Key"].endswith(".parquet"):
                 assert item["Key"] == (f"{enums.BucketPath.LAST_VALID.value}{upload_path}")
             elif item["Key"].endswith(".csv"):
-                assert f"{upload_path.replace('.parquet','.csv')}" in item["Key"]
+                assert f"{upload_path.replace('.parquet', '.csv')}" in item["Key"]
             else:
-                raise Exception("Invalid csv found at " f"{item['Key']}")
+                raise Exception(f"Invalid csv found at {item['Key']}")
         else:
             assert (
                 item["Key"].startswith(enums.BucketPath.ARCHIVE.value)

--- a/tests/site_upload/test_process_upload.py
+++ b/tests/site_upload/test_process_upload.py
@@ -25,17 +25,15 @@ from tests.mock_utils import (
     [
         (  # Adding a new data package to a site with uploads
             "./tests/test_data/cube_simple_example.parquet",
-            f"/{EXISTING_STUDY}/{NEW_DATA_P}/{EXISTING_SITE}"
-            f"/{EXISTING_VERSION}/document.parquet",
-            f"/{EXISTING_STUDY}/{NEW_DATA_P}/{EXISTING_SITE}"
-            f"/{EXISTING_VERSION}/document.parquet",
+            f"/{EXISTING_STUDY}/{NEW_DATA_P}/{EXISTING_SITE}/{EXISTING_VERSION}/document.parquet",
+            f"/{EXISTING_STUDY}/{NEW_DATA_P}/{EXISTING_SITE}/{EXISTING_VERSION}/document.parquet",
             200,
             ITEM_COUNT + 1,
         ),
         (  # Adding a new data package to a site without uploads
             "./tests/test_data/cube_simple_example.parquet",
-            f"/{EXISTING_STUDY}/{NEW_DATA_P}/{NEW_SITE}" f"/{EXISTING_VERSION}/document.parquet",
-            f"/{EXISTING_STUDY}/{NEW_DATA_P}/{NEW_SITE}" f"/{EXISTING_VERSION}/document.parquet",
+            f"/{EXISTING_STUDY}/{NEW_DATA_P}/{NEW_SITE}/{EXISTING_VERSION}/document.parquet",
+            f"/{EXISTING_STUDY}/{NEW_DATA_P}/{NEW_SITE}/{EXISTING_VERSION}/document.parquet",
             200,
             ITEM_COUNT + 1,
         ),
@@ -50,10 +48,8 @@ from tests.mock_utils import (
         ),
         (  # New version of an existing data package
             "./tests/test_data/cube_simple_example.parquet",
-            f"/{EXISTING_STUDY}/{EXISTING_DATA_P}/{EXISTING_SITE}"
-            f"/{NEW_VERSION}/encounter.parquet",
-            f"/{EXISTING_STUDY}/{EXISTING_DATA_P}/{EXISTING_SITE}"
-            f"/{NEW_VERSION}/encounter.parquet",
+            f"/{EXISTING_STUDY}/{EXISTING_DATA_P}/{EXISTING_SITE}/{NEW_VERSION}/encounter.parquet",
+            f"/{EXISTING_STUDY}/{EXISTING_DATA_P}/{EXISTING_SITE}/{NEW_VERSION}/encounter.parquet",
             200,
             ITEM_COUNT + 1,
         ),
@@ -77,8 +73,8 @@ from tests.mock_utils import (
         ),
         (  # Non-parquet file
             "./tests/test_data/cube_simple_example.csv",
-            f"/{EXISTING_STUDY}/{NEW_DATA_P}/{EXISTING_SITE}" f"/{EXISTING_VERSION}/document.csv",
-            f"/{EXISTING_STUDY}/{NEW_DATA_P}/{EXISTING_SITE}" f"/{EXISTING_VERSION}/document.csv",
+            f"/{EXISTING_STUDY}/{NEW_DATA_P}/{EXISTING_SITE}/{EXISTING_VERSION}/document.csv",
+            f"/{EXISTING_STUDY}/{NEW_DATA_P}/{EXISTING_SITE}/{EXISTING_VERSION}/document.csv",
             500,
             ITEM_COUNT + 1,
         ),

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,359 @@
+"""
+The intent of this test is to check the most common front to back workflow in the
+aggregator, i.e. given a file has been uploaded, is it available to be retrieved
+from the dashboard chart API. Failure cases are left to the various unit tests,
+this is intended to cover interactions across the various lambdas.
+
+We have to mock a lot of AWS infrastructure to do this, since we can't do event
+processing or athena queries locally.
+"""
+
+import json
+import pathlib
+from unittest import mock
+
+import boto3
+import pandas
+import pytest
+from freezegun import freeze_time
+from moto.core import DEFAULT_ACCOUNT_ID
+from moto.sns import sns_backends
+
+from scripts import reset_data_package_cache
+from src.dashboard.get_chart_data import get_chart_data
+from src.dashboard.get_data_packages import get_data_packages
+from src.dashboard.get_from_parquet import get_from_parquet
+from src.shared import enums, functions
+from src.site_upload.cache_api import cache_api
+from src.site_upload.powerset_merge import powerset_merge
+from src.site_upload.process_flat import process_flat
+from src.site_upload.process_upload import process_upload
+from tests import mock_utils
+
+"""
+
+"""
+CURRENT_COL_TYPES_VERSION = "3"
+
+
+@freeze_time("2025-06-06")
+@pytest.mark.parametrize(
+    "upload_file,upload_type,study,site,data_package,version,existing,run_migration",
+    [
+        (
+            pathlib.Path(__file__).parent / "test_data/mock_cube_col_types.parquet",
+            "cube",
+            mock_utils.NEW_STUDY,
+            mock_utils.NEW_SITE,
+            mock_utils.NEW_DATA_P,
+            mock_utils.NEW_VERSION,
+            False,
+            False,
+        ),
+        (
+            pathlib.Path(__file__).parent / "test_data/mock_cube_col_types.parquet",
+            "cube",
+            mock_utils.NEW_STUDY,
+            mock_utils.NEW_SITE,
+            mock_utils.NEW_DATA_P,
+            mock_utils.NEW_VERSION,
+            False,
+            True,
+        ),
+        (
+            pathlib.Path(__file__).parent / "test_data/mock_cube_col_types.parquet",
+            "cube",
+            mock_utils.EXISTING_STUDY,
+            mock_utils.EXISTING_SITE,
+            mock_utils.EXISTING_DATA_P,
+            mock_utils.EXISTING_VERSION,
+            True,
+            False,
+        ),
+        (
+            pathlib.Path(__file__).parent / "test_data/mock_cube_col_types.parquet",
+            "cube",
+            mock_utils.EXISTING_STUDY,
+            mock_utils.EXISTING_SITE,
+            mock_utils.EXISTING_DATA_P,
+            mock_utils.EXISTING_VERSION,
+            True,
+            True,
+        ),
+        (
+            pathlib.Path(__file__).parent / "test_data/flat_synthea_q_date_recent.parquet",
+            "flat",
+            mock_utils.NEW_STUDY,
+            mock_utils.NEW_SITE,
+            mock_utils.NEW_FLAT_DATA_P,
+            mock_utils.NEW_VERSION,
+            False,
+            False,
+        ),
+        (
+            pathlib.Path(__file__).parent / "test_data/flat_synthea_q_date_recent.parquet",
+            "flat",
+            mock_utils.NEW_STUDY,
+            mock_utils.NEW_SITE,
+            mock_utils.NEW_FLAT_DATA_P,
+            mock_utils.NEW_VERSION,
+            False,
+            True,
+        ),
+        (
+            pathlib.Path(__file__).parent / "test_data/flat_synthea_q_date_recent.parquet",
+            "flat",
+            mock_utils.EXISTING_STUDY,
+            mock_utils.EXISTING_SITE,
+            mock_utils.EXISTING_FLAT_DATA_P,
+            mock_utils.EXISTING_VERSION,
+            True,
+            False,
+        ),
+        (
+            pathlib.Path(__file__).parent / "test_data/flat_synthea_q_date_recent.parquet",
+            "flat",
+            mock_utils.EXISTING_STUDY,
+            mock_utils.EXISTING_SITE,
+            mock_utils.EXISTING_FLAT_DATA_P,
+            mock_utils.EXISTING_VERSION,
+            True,
+            True,
+        ),
+    ],
+)
+def test_integration(
+    tmp_path,
+    mock_bucket,
+    mock_notification,
+    upload_file,
+    upload_type,
+    study,
+    site,
+    data_package,
+    version,
+    existing,
+    run_migration,
+):
+    s3_client = boto3.client("s3", region_name="us-east-1")
+    sns_backend = sns_backends[DEFAULT_ACCOUNT_ID]["us-east-1"]
+    upload_key = (
+        f"site_upload/{study}/{study}__{data_package}/{site}/{version}"
+        f"/user__{site}__{study}.{upload_type}.parquet"
+    )
+
+    # Expected tables based on the mock bucket configuration
+    tables = [
+        f"{mock_utils.EXISTING_STUDY}__{mock_utils.EXISTING_DATA_P}__{mock_utils.EXISTING_VERSION}",
+        f"{mock_utils.OTHER_STUDY}__{mock_utils.EXISTING_DATA_P}__{mock_utils.EXISTING_VERSION}",
+        f"{mock_utils.EXISTING_STUDY}__{mock_utils.EXISTING_FLAT_DATA_P}__{mock_utils.EXISTING_SITE}__{mock_utils.EXISTING_VERSION}",
+        f"{mock_utils.OTHER_STUDY}__{mock_utils.EXISTING_FLAT_DATA_P}__{mock_utils.EXISTING_SITE}__{mock_utils.EXISTING_VERSION}",
+    ]
+
+    # Get a copy of the uploaded file into memory for reference later
+    reference_df = pandas.read_parquet(upload_file)
+
+    # Make sure that the migration is not introducing any unusual behavior,
+    # or if not running, ensure that the test bucket configuration is behaving
+    # the same way
+    if run_migration:
+        with mock.patch(
+            "awswrangler.athena.read_sql_query",
+            lambda query, database, s3_output, workgroup: pandas.DataFrame(
+                data=pandas.DataFrame({"table_name": tables})
+            ),
+        ):
+            reset_data_package_cache.reset_data_package_cache(mock_utils.TEST_BUCKET, "mock_db")
+
+    # grab the data packages list before modifications for later validation
+    dp_before_event = {
+        "queryStringParameters": [],
+        "multiValueQueryStringParameters": {},
+        "pathParameters": [],
+    }
+    dp_before = get_data_packages.data_packages_handler(dp_before_event, [])
+
+    # Mock the upload and the event kicking off the aggregator processing pipeline
+    s3_client.upload_file(upload_file, mock_utils.TEST_BUCKET, upload_key)
+    upload_event = {"Records": [{"awsRegion": "us-east-1", "s3": {"object": {"key": upload_key}}}]}
+    upload_res = process_upload.process_upload_handler(upload_event, {})
+    assert upload_res["statusCode"] == 200
+
+    # We'll need to construct events from the moto sns mock message backend, which looks like this:
+    # [(event_id, s3_key, event id, unused field, unused field)]
+    # Then we'll pass to the appropriate handler based on type
+
+    if upload_type == enums.UploadTypes.CUBE.value:
+        counts_sns = sns_backend.topics[mock_utils.TEST_PROCESS_COUNTS_ARN].sent_notifications
+        counts_event = {
+            "Records": [
+                {
+                    "Sns": {
+                        "TopicArn": mock_utils.TEST_PROCESS_COUNTS_ARN,
+                        "Message": counts_sns[0][1],
+                    }
+                }
+            ]
+        }
+        merge_res = powerset_merge.powerset_merge_handler(counts_event, {})
+        assert merge_res["statusCode"] == 200
+
+    elif upload_type == enums.UploadTypes.FLAT.value:
+        counts_sns = sns_backend.topics[mock_utils.TEST_PROCESS_FLAT_ARN].sent_notifications
+        counts_event = {
+            "Records": [
+                {"Sns": {"TopicArn": mock_utils.TEST_PROCESS_FLAT_ARN, "Message": counts_sns[0][1]}}
+            ]
+        }
+        merge_res = process_flat.process_flat_handler(counts_event, {})
+        assert merge_res["statusCode"] == 200
+
+    # The cache is triggered by an S3 event set up in the cloudformation template. We'll have
+    # to mock this event as well by expected file path
+    cache_event = {"Records": [{"Sns": {"Subject": enums.JsonFilename.DATA_PACKAGES.value}}]}
+    # Add an extra table to the list if we've created one, and mock the table list for cache_api
+    if upload_type == enums.UploadTypes.CUBE.value:
+        if f"{study}__{data_package}__{version}" not in tables:
+            tables.append(f"{study}__{data_package}__{version}")
+    elif upload_type == enums.UploadTypes.FLAT.value:
+        if f"{study}__{data_package}__{site}__{version}" not in tables:
+            tables.append(f"{study}__{data_package}__{site}__{version}")
+    with mock.patch(
+        "awswrangler.athena.read_sql_query",
+        lambda query, database, s3_output, workgroup: pandas.DataFrame(
+            data=pandas.DataFrame({"table_name": tables})
+        ),
+    ):
+        cache_res = cache_api.cache_api_handler(cache_event, {})
+        assert cache_res["statusCode"] == 200
+
+    # Then do some comparisons to the pre-processed version to make sure things ended up
+    # in the right place
+    dp_after = json.loads(get_data_packages.data_packages_handler({}, [])["body"])
+    if existing:
+        len(dp_after) == len(dp_before)
+    else:
+        len(dp_after) == len(dp_before) + 1
+        match upload_type:
+            case enums.UploadTypes.CUBE.value:
+                expected_id = f"{study}__{data_package}__{version}"
+            case enums.UploadTypes.FLAT.value:
+                expected_id = f"{study}__{data_package}__{site}__{version}"
+        if not any(x["id"] == expected_id for x in dp_after):
+            raise KeyError("Expected data package id not found")
+    for dp in dp_after:
+        assert CURRENT_COL_TYPES_VERSION == dp["column_types_format_version"]
+        assert len(dp["id"].split("__")) == 3 or len(dp["id"].split("__")) == 4
+        if (
+            upload_type == enums.UploadTypes.CUBE.value
+            and dp["id"] == f"{study}__{data_package}__{version}"
+        ) or (
+            upload_type == enums.UploadTypes.FLAT.value
+            and dp["id"] == f"{study}__{data_package}__{site}__{version}"
+        ):
+            assert version == dp["version"]
+            assert study == dp["study"]
+            match upload_type:
+                case enums.UploadTypes.CUBE.value:
+                    assert data_package == dp["name"]
+                    assert (reference_df["cnt"].max()) == dp["total"]
+                case enums.UploadTypes.FLAT.value:
+                    assert data_package == f"{dp['name'].split('__')[0]}"
+            for column in dp["columns"]:
+                assert dp["columns"][column]["type"] in (
+                    "year",
+                    "month",
+                    "week",
+                    "day",
+                    "integer",
+                    "float",
+                    "double",
+                    "boolean",
+                    "string",
+                )
+                if (
+                    not (column.startswith("cnt") or column == "site")
+                    and upload_type == enums.UploadTypes.CUBE.value
+                ):
+                    assert (
+                        reference_df[column].nunique()
+                        == dp["columns"][column]["distinct_values_count"]
+                    )
+            assert "2025-06-06T00:00:00+00:00" == dp["last_data_update"]
+            chart_cols = dp["columns"]
+            s3_path = dp["s3_path"]
+
+    # We'll download the post-processing file from the mock bucket to fake query responses
+    # from athena for getting individual chart data.
+    # The mock bucket get_object doesn't implement seek, so we'll write a copy to disk
+    with open(tmp_path / "processed.parquet", "wb") as f:
+        f.write(
+            s3_client.get_object(
+                Bucket=mock_utils.TEST_BUCKET, Key=functions.get_s3_key_from_path(s3_path)
+            )["Body"].read()
+        )
+    post_process_df = pandas.read_parquet(tmp_path / "processed.parquet")
+
+    # We'll approximate a sql query by slicing and returning unique values from
+    # the post_process df
+    def parse_select(query, database, s3_output, workgroup):
+        cols = query.split("SELECT")[1].split("FROM")[0].replace('"', "").split(",")
+        cols = [x.strip() for x in cols]
+        selected = post_process_df[cols].drop_duplicates()
+        na_fills = {}
+        for column in selected.columns:
+            if selected[column].dtype == "boolean":
+                na_fills[column] = False
+            else:
+                na_fills[column] = "cumulus__none"
+        return post_process_df[cols].drop_duplicates().fillna(na_fills)
+
+    # Finally, we'll check the default endpoint once, and then iterate
+    # through all the stratifier combinations to make sure we have valid
+    # looking column/stratifier names
+    match upload_type:
+        case enums.UploadTypes.CUBE.value:
+            chart_event = {
+                "queryStringParameters": {"column": "site"},
+                "multiValueQueryStringParameters": {},
+                "pathParameters": {"data_package_id": f"{study}__{data_package}__{version}"},
+            }
+            with mock.patch("awswrangler.athena.read_sql_query", parse_select):
+                chart_res = get_chart_data.chart_data_handler(chart_event, {})
+            assert chart_res["statusCode"] == 200
+            if upload_type == enums.UploadTypes.FLAT.value:
+                return
+            for column in chart_cols:
+                if column == "cnt":
+                    continue
+                for stratifier in chart_cols:
+                    if column == stratifier or stratifier == "cnt":
+                        continue
+                    chart_event = {
+                        "queryStringParameters": {"column": column, "stratifier": stratifier},
+                        "multiValueQueryStringParameters": {},
+                        "pathParameters": {
+                            "data_package_id": f"{study}__{data_package}__{version}"
+                        },
+                    }
+                    with mock.patch("awswrangler.athena.read_sql_query", parse_select):
+                        chart_res = get_chart_data.chart_data_handler(chart_event, {})
+                    assert chart_res["statusCode"] == 200
+                    body = json.loads(chart_res["body"])
+                    expected_vals = body["counts"].keys()
+                    for section in body["data"]:
+                        for row in section["rows"]:
+                            assert row[0] in expected_vals
+
+        # Or, if it's flat, we'll just check to make sure that it's the originally uploaded file
+        case enums.UploadTypes.FLAT.value:
+            parquet_event = {
+                "queryStringParameters": {"type": "csv", "s3_path": s3_path},
+                "multiValueQueryStringParameters": {},
+                "pathParameters": {},
+            }
+            csv_res = get_from_parquet.from_parquet_handler(parquet_event, {})
+            with open(tmp_path / "flat.csv", "w") as f:
+                f.write(csv_res["body"])
+            csv_df = pandas.read_csv(tmp_path / "flat.csv")
+            assert reference_df.compare(csv_df).empty


### PR DESCRIPTION
- Adds end to end integration tests for cube & flat files, including resetting the cache manually
- Fixes an issue with date updates in flat files #174 
- Fixes a case in the chart data endpoint where additional casting was required for pandas indexes