### PR TITLE
pinned numpy version for aws python 3.11 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies= [
     "cumulus-library >=4.1",
     "Jinja2 >=3.1.4, <4",
     "pandas >=2, <3",
+    "numpy==2.2.1", # GCC version compatibility pin - see https://github.com/numpy/numpy/issues/29150
     "requests", # scripts only
     "rich",
 ]


### PR DESCRIPTION
So there's now a compiler compatibility issue in the AWS lambda build environment with python 3.11: see https://github.com/numpy/numpy/issues/29150

This PR pins the numpy version for now. At some point we'll jump to python 3.13, which should address this in a longer term way.