### PR TITLE
Stage downloads to S3

### DIFF
--- a/src/dashboard/get_from_parquet/get_from_parquet.py
+++ b/src/dashboard/get_from_parquet/get_from_parquet.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import awswrangler
 import pyarrow
 
@@ -25,9 +27,10 @@ def from_parquet_handler(event, context):
 
     else:
         data = df.to_json(orient="table", index=False)
-    temp_path = f"{enums.BucketPath.TEMP.value}/{functions.get_s3_key_from_path(s3_path)}"
+    ts = datetime.utcnow().timestamp()
+    temp_path = f"{enums.BucketPath.TEMP.value}/{ts}/{functions.get_s3_key_from_path(s3_path)}"
     manager = s3_manager.S3Manager(event)
     manager.write_data_to_file(data=data, path=temp_path)
     url = manager.get_presigned_download_url(temp_path)
-    res = functions.http_response(302, {"location": url})
+    res = functions.http_response(302, None, extra_headers={"location": url})
     return res

--- a/src/shared/enums.py
+++ b/src/shared/enums.py
@@ -4,7 +4,7 @@ import enum
 
 
 class BucketPath(enum.Enum):
-    """stores root level buckets for managing data processing state"""
+    """stores root level subbuckets for managing data processing state"""
 
     ADMIN = "admin"
     AGGREGATE = "aggregates"
@@ -17,6 +17,7 @@ class BucketPath(enum.Enum):
     META = "metadata"
     STATIC = "static"
     STUDY_META = "study_metadata"
+    TEMP = "temp"
     UPLOAD = "site_upload"
 
 

--- a/src/shared/s3_manager.py
+++ b/src/shared/s3_manager.py
@@ -140,7 +140,9 @@ class S3Manager:
                 ExpiresIn=expiration,
             )
             return res
-        except botocore.exceptions.ClientError as e:
+        # Exempting this from coverage because moto does not check for presence
+        # before trying to presign a URL
+        except botocore.exceptions.ClientError as e:  # pragma: no cover
             logging.error(e)
             return None
 

--- a/src/shared/s3_manager.py
+++ b/src/shared/s3_manager.py
@@ -4,6 +4,7 @@ import traceback
 
 import awswrangler
 import boto3
+import botocore
 import pandas
 
 from shared import (
@@ -28,38 +29,41 @@ class S3Manager:
 
     def __init__(self, event):
         self.s3_bucket_name = os.environ.get("BUCKET_NAME")
-        self.s3_client = boto3.client("s3")
+        self.s3_client = boto3.client("s3", config=boto3.session.Config(signature_version="s3v4"))
         self.sns_client = boto3.client("sns", region_name=self.s3_client.meta.region_name)
-        self.event_source = event["Records"][0]["Sns"]["TopicArn"]
-        self.s3_key = event["Records"][0]["Sns"]["Message"]
-        dp_meta = functions.parse_s3_key(self.s3_key)
-        self.study = dp_meta.study
-        self.data_package = dp_meta.data_package
-        self.site = dp_meta.site
-        self.version = dp_meta.version
-        self.metadata = functions.read_metadata(
-            self.s3_client, self.s3_bucket_name, meta_type=enums.JsonFilename.TRANSACTIONS.value
-        )
-        self.types_metadata = functions.read_metadata(
-            self.s3_client,
-            self.s3_bucket_name,
-            meta_type=enums.JsonFilename.COLUMN_TYPES.value,
-        )
-        self.parquet_aggregate_path = (
-            f"s3://{self.s3_bucket_name}/{enums.BucketPath.AGGREGATE.value}/"
-            f"{self.study}/{self.study}__{self.data_package}/"
-            f"{self.study}__{self.data_package}__{self.version}/"
-            f"{self.study}__{self.data_package}__aggregate.parquet"
-        )
+        # If the event is an SNS type event, we're in the aggregation pipeline and set up
+        # some convenience values.
+        if "Records" in event:
+            self.event_source = event["Records"][0]["Sns"]["TopicArn"]
+            self.s3_key = event["Records"][0]["Sns"]["Message"]
+            dp_meta = functions.parse_s3_key(self.s3_key)
+            self.study = dp_meta.study
+            self.data_package = dp_meta.data_package
+            self.site = dp_meta.site
+            self.version = dp_meta.version
+            self.metadata = functions.read_metadata(
+                self.s3_client, self.s3_bucket_name, meta_type=enums.JsonFilename.TRANSACTIONS.value
+            )
+            self.types_metadata = functions.read_metadata(
+                self.s3_client,
+                self.s3_bucket_name,
+                meta_type=enums.JsonFilename.COLUMN_TYPES.value,
+            )
+            self.parquet_aggregate_path = (
+                f"s3://{self.s3_bucket_name}/{enums.BucketPath.AGGREGATE.value}/"
+                f"{self.study}/{self.study}__{self.data_package}/"
+                f"{self.study}__{self.data_package}__{self.version}/"
+                f"{self.study}__{self.data_package}__aggregate.parquet"
+            )
 
-        # TODO: Taking out a folder layer to match the depth of non-site aggregates
-        # Revisit when targeted crawling is implemented
-        self.parquet_flat_key = (
-            f"{enums.BucketPath.FLAT.value}/"
-            f"{self.study}/{self.site}/"  # {self.study}__{self.data_package}/"
-            f"{self.study}__{self.data_package}__{self.site}__{self.version}/"
-            f"{self.study}__{self.data_package}__{self.site}__flat.parquet"
-        )
+            # TODO: Taking out a folder layer to match the depth of non-site aggregates
+            # Revisit when targeted crawling is implemented
+            self.parquet_flat_key = (
+                f"{enums.BucketPath.FLAT.value}/"
+                f"{self.study}/{self.site}/"  # {self.study}__{self.data_package}/"
+                f"{self.study}__{self.data_package}__{self.site}__{self.version}/"
+                f"{self.study}__{self.data_package}__{self.site}__flat.parquet"
+            )
 
     def error_handler(
         self,
@@ -81,27 +85,64 @@ class S3Manager:
         self.update_local_metadata(enums.TransactionKeys.LAST_ERROR.value)
 
     # S3 Filesystem operations
-    def copy_file(self, from_path_or_key: str, to_path_or_key: str) -> None:
+    def copy_file(self, from_path: str, to_path: str) -> None:
         """Copies a file from one location to another in S3.
 
-        This function is agnostic to being provided an S3 path versus an S3 key.
-
-        :param from_path_or_key: the data source
-        :param to_path_or_key: the data destination.
+        :param from_path: the data source S3 path or key
+        :param to_path: the data destinationS3 path or key
         """
-        if from_path_or_key.startswith("s3"):
-            from_path_or_key = from_path_or_key.split("/", 3)[-1]
-        if to_path_or_key.startswith("s3"):
-            to_path_or_key = to_path_or_key.split("/", 3)[-1]
+        from_path = functions.get_s3_key_from_path(from_path)
+        to_path = functions.get_s3_key_from_path(to_path)
         source = {
             "Bucket": self.s3_bucket_name,
-            "Key": from_path_or_key,
+            "Key": from_path,
         }
         self.s3_client.copy_object(
             CopySource=source,
             Bucket=self.s3_bucket_name,
-            Key=to_path_or_key,
+            Key=to_path,
         )
+
+    def write_data_to_file(self, data: str, path: str) -> None:
+        """Creates a file in s3 from a string
+
+        :param data: The string to write
+        :param path: The key or full S3 path
+        """
+        path = functions.get_s3_key_from_path(path)
+        data = str.encode(data, encoding="utf-8")
+        self.s3_client.put_object(Bucket=self.s3_bucket_name, Key=path, Body=data)
+
+    def move_file(self, from_path: str, to_path: str) -> None:
+        """Moves file from one location to another in s3
+
+        :param from_path: the data source S3 path or key
+        :param to_path: the data destination S3 path or key
+
+        """
+        from_path = functions.get_s3_key_from_path(from_path)
+        to_path = functions.get_s3_key_from_path(to_path)
+        functions.move_s3_file(self.s3_client, self.s3_bucket_name, from_path, to_path)
+
+    def get_presigned_download_url(self, path: str, expiration=3600) -> dict | None:
+        """Generates a secure URL for upload without AWS credentials
+
+        :param path: an object s3 path or key
+        :param expiration: Time in seconds for url to be valid
+        :returns: A url, or None if no object at the location
+        """
+        path = functions.get_s3_key_from_path(path)
+
+        try:
+            res = self.s3_client.generate_presigned_url(
+                "get_object",
+                Params={"Bucket": self.s3_bucket_name, "Key": path},
+                ExpiresIn=expiration,
+            )
+            return res
+        except botocore.exceptions.ClientError as e:
+            logging.error(e)
+            return None
 
     def get_data_package_list(self, bucket_root) -> list:
         """Gets a list of data packages associated with the study from the SNS event payload.
@@ -111,23 +152,6 @@ class S3Manager:
         """
         return awswrangler_functions.get_s3_data_package_list(
             bucket_root, self.s3_bucket_name, self.study, self.data_package
-        )
-
-    def move_file(self, from_path_or_key: str, to_path_or_key: str) -> None:
-        """moves file from one location to another in s3
-
-        This function is agnostic to being provided an S3 path versus an S3 key.
-
-        :param from_path_or_key: the data source
-        :param to_path_or_key: the data destination.
-
-        """
-        if from_path_or_key.startswith("s3"):
-            from_path_or_key = from_path_or_key.split("/", 3)[-1]
-        if to_path_or_key.startswith("s3"):
-            to_path_or_key = to_path_or_key.split("/", 3)[-1]
-        functions.move_s3_file(
-            self.s3_client, self.s3_bucket_name, from_path_or_key, to_path_or_key
         )
 
     # parquet output creation

--- a/template.yaml
+++ b/template.yaml
@@ -645,7 +645,7 @@ Resources:
         ApplicationLogLevel: !Ref LogLevel
         LogFormat: !Ref LogFormat
         LogGroup: !Sub "/aws/lambda/CumulusAggDashboardFromParquet-${DeployStage}-${NetworkName}"
-      MemorySize: 512
+      MemorySize: 2048
       Timeout: 100
       Description: Retrieve data from a parquet source
       Environment:
@@ -660,6 +660,8 @@ Resources:
             Method: GET
       Policies:
         - S3ReadPolicy:
+            BucketName: !Sub '${BucketNameParameter}-${AWS::AccountId}-${DeployStage}-${NetworkName}'
+        - S3WritePolicy:
             BucketName: !Sub '${BucketNameParameter}-${AWS::AccountId}-${DeployStage}-${NetworkName}'
         - Statement:
           - Sid: DecryptPolicy
@@ -889,6 +891,14 @@ Resources:
                 Rules:
                   - Name: prefix
                     Value: 'site_upload/'
+      LifecycleConfiguration:
+        Rules:
+          - Id: TempfileCleanup
+            Prefix: temp
+            # This is applied at midnight UTC, so we keep things around for an extra day
+            # to prevent files being deleted during download
+            ExpirationInDays: 2
+            Status: Enabled
 
 ### Glue Resources
 

--- a/tests/dashboard/test_get_from_parquet.py
+++ b/tests/dashboard/test_get_from_parquet.py
@@ -2,6 +2,7 @@ import json
 import os
 from unittest import mock
 
+import boto3
 import pytest
 
 from src.dashboard.get_from_parquet import get_from_parquet
@@ -17,7 +18,12 @@ def mock_event(target, payload_type):
     return payload
 
 
-S3_PATH = f"s3://{TEST_BUCKET}/aggregates/study/study__encounter/study__encounter__099/study__encounter__aggregate.parquet"
+S3_KEY = (
+    "aggregates/study/study__encounter/study__encounter__099/study__encounter__aggregate.parquet"
+)
+S3_PATH = f"s3://{TEST_BUCKET}/{S3_KEY}"
+S3_TEMP_KEY = f"temp/{S3_KEY}"
+S3_TEMP_PATH = f"https://{TEST_BUCKET}.s3.amazonaws.com/"
 
 
 @pytest.mark.parametrize(
@@ -27,7 +33,7 @@ S3_PATH = f"s3://{TEST_BUCKET}/aggregates/study/study__encounter/study__encounte
         (
             S3_PATH,
             None,
-            200,
+            302,
             506,
             {"cnt": 1103, "gender": None, "age": None, "race_display": None, "site": None},
             {
@@ -48,7 +54,7 @@ S3_PATH = f"s3://{TEST_BUCKET}/aggregates/study/study__encounter/study__encounte
         (
             S3_PATH,
             "json",
-            200,
+            302,
             506,
             {"cnt": 1103, "gender": None, "age": None, "race_display": None, "site": None},
             {
@@ -69,7 +75,7 @@ S3_PATH = f"s3://{TEST_BUCKET}/aggregates/study/study__encounter/study__encounte
         (
             S3_PATH,
             "csv",
-            200,
+            302,
             507,
             "cnt,gender,age,race_display,site",
             "10,,78,Not Hispanic or Latino,princeton_plainsboro_teaching_hospital",
@@ -78,7 +84,7 @@ S3_PATH = f"s3://{TEST_BUCKET}/aggregates/study/study__encounter/study__encounte
         (
             S3_PATH,
             "tsv",
-            200,
+            302,
             507,
             "cnt|gender|age|race_display|site",
             "10||78|Not Hispanic or Latino|princeton_plainsboro_teaching_hospital",
@@ -91,25 +97,24 @@ def test_get_data_packages(mock_bucket, target, payload_type, code, length, firs
     payload = mock_event(target, payload_type)
     res = get_from_parquet.from_parquet_handler(payload, {})
     assert (res["statusCode"]) == code
-    if code == 200:
+    if code == 302:
+        url = json.loads(res["body"])["location"]
+        assert url.startswith(S3_TEMP_PATH)
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        res = s3_client.get_object(Bucket=TEST_BUCKET, Key=S3_TEMP_KEY)
+        file = res["Body"].read().decode("utf-8")
         if payload_type is None or payload_type == "json":
-            assert res["headers"] == {"Content-Type": "application/json"}
-            res = json.loads(res["body"])
-            assert res["schema"]["fields"] == [
+            file = json.loads(file)
+            assert file["schema"]["fields"] == [
                 {"name": "cnt", "type": "integer", "extDtype": "Int64"},
                 {"name": "gender", "type": "any", "extDtype": "string"},
                 {"name": "age", "type": "integer", "extDtype": "Int64"},
                 {"name": "race_display", "type": "any", "extDtype": "string"},
                 {"name": "site", "type": "any", "extDtype": "string"},
             ]
-            res = res["data"]
+            file = file["data"]
         else:
-            assert res["headers"] == {
-                "Content-Type": "text/csv",
-                "Content-disposition": "attachment; filename=study__encounter__aggregate.csv",
-                "Content-Length": len(res["body"].encode("utf-8")),
-            }
-            res = res["body"].split("\n")[:-1]
-        assert len(res) == length
-        assert res[0] == first
-        assert res[-1] == last
+            file = file.split("\n")[:-1]
+        assert len(file) == length
+        assert file[0] == first
+        assert file[-1] == last

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -354,7 +354,7 @@ def test_integration(
             }
             csv_res = get_from_parquet.from_parquet_handler(parquet_event, {})
             assert csv_res["statusCode"] == 302
-            url = json.loads(csv_res["body"])["location"]
+            url = csv_res["headers"]["location"]
             key = url.split("?")[0].replace(
                 "https://cumulus-aggregator-site-counts-test.s3.amazonaws.com/", ""
             )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -353,7 +353,14 @@ def test_integration(
                 "pathParameters": {},
             }
             csv_res = get_from_parquet.from_parquet_handler(parquet_event, {})
+            assert csv_res["statusCode"] == 302
+            url = json.loads(csv_res["body"])["location"]
+            key = url.split("?")[0].replace(
+                "https://cumulus-aggregator-site-counts-test.s3.amazonaws.com/", ""
+            )
+            res = s3_client.get_object(Bucket=mock_utils.TEST_BUCKET, Key=key)
+            file = res["Body"].read().decode("utf-8")
             with open(tmp_path / "flat.csv", "w") as f:
-                f.write(csv_res["body"])
+                f.write(file)
             csv_df = pandas.read_csv(tmp_path / "flat.csv")
             assert reference_df.compare(csv_df).empty


### PR DESCRIPTION
Since lambdas have very tight caps on the size of payloads they can create, we're writing them to S3 and then issuing a pre-signed URL, and letting that handle the download portion.

There's also some light cleanup of some string splicing in shared.functions.