### PR TITLE
Dedupe eventbridge event

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1175,25 +1175,11 @@ Resources:
     Properties:
       DelaySeconds: !Ref TransactionDelay
 
-  SQSTransactionEventSource:
-    Type: AWS::Lambda::EventSourceMapping
-    Properties:
-      EventSourceArn: !GetAtt SQSTransactionCleanup.Arn
-      FunctionName:
-        !Ref TransactionCleanupFunction
-
   SQSMetadataUpdate:
     Type: AWS::SQS::Queue
     Properties:
       FifoQueue: True
       ContentBasedDeduplication: True
-
-  SQSMetadataUpdateEventSource:
-    Type: AWS::Lambda::EventSourceMapping
-    Properties:
-      EventSourceArn: !GetAtt SQSMetadataUpdate.Arn
-      FunctionName:
-        !Ref ProcessMetadataFunction
 
 # EventBridge rules
 


### PR DESCRIPTION
The event mapping defined in the process metadata lambda in the Serverless template format is creating the same class of eventsource mapping that we were explicitly defining in the queue section, resulting in a duplicate mapping which causes deployments to fail, but only sometimes. This removes the manual eventsource definition.