### PR TITLE
Restore metadata queue

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1190,6 +1190,13 @@ Resources:
       FifoQueue: True
       ContentBasedDeduplication: True
 
+  SQSMetadataUpdateEventSource:
+    Type: AWS::Lambda::EventSourceMapping
+    Properties:
+      EventSourceArn: !GetAtt SQSMetadataUpdate.Arn
+      FunctionName:
+        !Ref ProcessMetadataFunction
+
 # EventBridge rules
 
   GlueCrawlCompleteRule:


### PR DESCRIPTION
Looks like cloudformation is just really bad about cleaning up eventbridge rules. This was causing a lot of churn when there were other changes happening at the same time, but as a solo one and done it seems to be ok - but we'll have to manually remove rules if we ever need to update them.