### PR TITLE
removed serverless mapping for fifo queue

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -417,11 +417,6 @@ Resources:
       Environment:
         Variables:
           BUCKET_NAME: !Sub '${BucketNameParameter}-${AWS::AccountId}-${DeployStage}-${NetworkName}'
-      Events:
-        MetadataUpdateSQSEvent:
-          Type: SQS
-          Properties:
-            Queue: !GetAtt SQSMetadataUpdate.Arn
       Policies:
         - S3CrudPolicy:
             BucketName: !Sub '${BucketNameParameter}-${AWS::AccountId}-${DeployStage}-${NetworkName}'


### PR DESCRIPTION
The serverless transform is trying to create its own event mapping under the hood - since we're doing it explicitly to set advanced queue parameters, we'll remove the declaration from the lambda.