### PR TITLE
Changed chart data counts to not use stratifiers

### DIFF
--- a/src/dashboard/get_chart_data/get_chart_data.py
+++ b/src/dashboard/get_chart_data/get_chart_data.py
@@ -11,7 +11,7 @@ import boto3
 import jinja2
 import pandas
 
-from shared import enums, errors, functions
+from shared import decorators, enums, errors, functions
 
 log_level = os.environ.get("LAMBDA_LOG_LEVEL", "INFO")
 logger = logging.getLogger()
@@ -252,7 +252,7 @@ def _format_payload(
         # so let's convert it to a python primitive
         counts.index = counts.index.astype(str)
         payload["counts"] = counts.to_dict()[(count_col, "sum")]
-        payload["totalCount"] = int(counts["cnt"].sum())
+        payload["totalCount"] = int(counts["cnt"].sum().iloc[0])
         data = []
 
         # We are combining two values into a pandas index. This means that we've got
@@ -304,7 +304,7 @@ def _format_payload(
     return payload
 
 
-# @decorators.generic_error_handler(msg="Error retrieving chart data")
+@decorators.generic_error_handler(msg="Error retrieving chart data")
 def chart_data_handler(event, context):
     """manages event from dashboard api call and retrieves data"""
     del context

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -359,7 +359,7 @@ def test_integration(
 
     # We'll approximate a sql query by slicing and returning unique values from
     # the post_process df
-    def _parse_select(query, database, s3_output, workgroup):
+    def _parse_select(query, database, s3_output, workgroup, ctas_approach=True):
         def _clean_col(col):
             # if we're aggregating for a case with filters for cols outside of
             # the charted columns, just return the column alias


### PR DESCRIPTION
This addresses #213 by trying to calculate the column totals using an unstratified table, to account for cases where a counted resource may be present in more than one column (which bloats the total). This means statifications might be a little lower, percentage wise, due to small bin sizes, which we've been assured we're ok with.