### PR TITLE
Updated for library v6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cumulus-aggregator"
-requires-python = ">= 3.10"
+requires-python = ">= 3.11"
 version = "0.3.0"
 # This project is designed to run on the AWS serverless application framework (SAM).
 # The project dependencies are handled via AWS layers. These are only required for
@@ -9,7 +9,7 @@ dependencies= [
     "arrow >=1.2.3",
     "awswrangler >=3.5, <4",
     "boto3",
-    "cumulus-library >=4.1, < 5",
+    "cumulus-library >=6, < 7",
     "Jinja2 >=3.1.4, <4",
     "pandas >=2.3.3, <3",
     "numpy==2.2.1", # GCC version compatibility pin - see https://github.com/numpy/numpy/issues/29150
@@ -39,7 +39,7 @@ build-backend = "flit_core.buildapi"
 test = [
     "coverage >=7.3.1",
     "duckdb >= 1.4.1",
-    "freezegun",
+    "time-machine",
     "moto[s3,athena,sns,sqs] >=5, <6",
     "pytest",
     "pytest-cov",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies= [
     "cumulus-library >=6, < 7",
     "Jinja2 >=3.1.4, <4",
     "pandas >=2.3.3, <3",
+    "pyparsing",
     "numpy==2.2.1", # GCC version compatibility pin - see https://github.com/numpy/numpy/issues/29150
     "requests", # scripts only
     "rich",

--- a/src/site_upload/check_if_complete/check_if_complete.py
+++ b/src/site_upload/check_if_complete/check_if_complete.py
@@ -8,7 +8,7 @@ from time import sleep
 import awswrangler
 import boto3
 
-from shared import decorators, enums, errors, functions
+from shared import enums, errors, functions
 
 logger = logging.getLogger()
 logger.setLevel("INFO")
@@ -123,7 +123,7 @@ def mock_entrypoint():
     pass
 
 
-@decorators.generic_error_handler(msg="Error processing metadata events")
+# decorators.generic_error_handler(msg="Error processing metadata events")
 def check_if_complete_handler(event, context):
     del context
     message = json.loads(event["Records"][0]["Sns"]["Message"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,10 +31,13 @@ import boto3
 import duckdb
 import moto
 import pytest
+import time_machine
 
 from scripts import credential_management
 from src.shared import enums, functions
 from tests import mock_utils
+
+time_machine.naive_mode = time_machine.NaiveMode.UTC
 
 
 def _init_mock_data(s3_client, bucket, study, data_package, version):

--- a/tests/dashboard/test_get_from_parquet.py
+++ b/tests/dashboard/test_get_from_parquet.py
@@ -5,7 +5,7 @@ from unittest import mock
 
 import boto3
 import pytest
-from freezegun import freeze_time
+import time_machine
 
 from src.dashboard.get_from_parquet import get_from_parquet
 from tests.mock_utils import MOCK_ENV, TEST_BUCKET
@@ -27,7 +27,7 @@ S3_PATH = f"s3://{TEST_BUCKET}/{S3_KEY}"
 S3_TEMP_PATH = f"https://{TEST_BUCKET}.s3.amazonaws.com/"
 
 
-@freeze_time("2020-01-01")
+@time_machine.travel("2020-01-01", tick=False)
 @pytest.mark.parametrize(
     "target,payload_type,code,length,first,last,schema",
     [

--- a/tests/dashboard/test_post_distribute.py
+++ b/tests/dashboard/test_post_distribute.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 import pytest
 import responses
-from freezegun import freeze_time
+import time_machine
 
 from src.dashboard.post_distribute import post_distribute
 
@@ -45,7 +45,7 @@ from src.dashboard.post_distribute import post_distribute
     ],
 )
 @responses.activate
-@freeze_time("2020-01-01")
+@time_machine.travel("2020-01-01", tick=False)
 def test_process_github(mock_notification, tmp_path, name, url, tag, expected_status, monkeypatch):
     responses.add(responses.GET, "https://github.com/smart-on-fhir/test_study", status=200)
     responses.add(responses.GET, "https://github.com/smart-on-fhir/test_study/tree/tag", status=200)

--- a/tests/dashboard/test_queue_distribute.py
+++ b/tests/dashboard/test_queue_distribute.py
@@ -7,7 +7,7 @@ from unittest import mock
 
 import pytest
 import responses
-from freezegun import freeze_time
+import time_machine
 
 from src.dashboard.queue_distribute import queue_distribute
 
@@ -43,7 +43,7 @@ def test_process_github(
     mock_notification, tmp_path, name, url, tag, expected_status, monkeypatch, fp
 ):
     fp.allow_unregistered(True)  # fp is provided by pytest-subprocess
-
+    print(tmp_path)
     args = ["--depth", "1", url, f"{tmp_path}/studies"]
     if tag:
         args = ["--branch", tag, *args]
@@ -64,7 +64,7 @@ def test_process_github(
     monkeypatch.setattr(queue_distribute, "BASE_DIR", tmp_path)
     mock_sns = mock.MagicMock()
     monkeypatch.setattr(queue_distribute, "sns_client", mock_sns)
-    with freeze_time("2020-01-01"):  # Don't use as a fixture for this test; collides with fp mock
+    with time_machine.travel("2020-01-01", tick=False):
         res = queue_distribute.queue_handler(
             {
                 "Records": [

--- a/tests/shared/test_functions.py
+++ b/tests/shared/test_functions.py
@@ -11,9 +11,9 @@ from contextlib import nullcontext as does_not_raise
 from unittest import mock
 
 import boto3
-import freezegun
 import pandas
 import pytest
+import time_machine
 
 from src.shared import enums, errors, functions, pandas_functions
 from tests import mock_utils
@@ -296,7 +296,7 @@ def test_parse_s3_key(key, expected, raises):
         ),
     ],
 )
-@freezegun.freeze_time("2020-01-01")
+@time_machine.travel("2020-01-01", tick=False)
 def test_construct_s3_key(subbucket, expected, raises):
     with raises:
         site = "site" if subbucket != enums.BucketPath.AGGREGATE else None

--- a/tests/shared/test_s3_manager.py
+++ b/tests/shared/test_s3_manager.py
@@ -5,9 +5,9 @@ from unittest import mock
 
 import boto3
 import botocore
-import freezegun
 import pandas
 import pytest
+import time_machine
 
 from src.shared import enums, functions, s3_manager
 from tests import mock_utils
@@ -347,7 +347,7 @@ def test_presigned_error_handling(mock_bucket):
         ),
     ],
 )
-@freezegun.freeze_time("2025-01-01")
+@time_machine.travel("2025-01-01", tick=False)
 def test_update_local_metadata(
     mock_bucket, site, study, data_package, version, metadata_type, target, extras, mock_queue
 ):

--- a/tests/site_upload/test_check_if_complete.py
+++ b/tests/site_upload/test_check_if_complete.py
@@ -1,6 +1,5 @@
 import json
 import time
-from datetime import datetime
 from unittest import mock
 
 import boto3
@@ -62,7 +61,7 @@ def delete_transaction():
     s3_client.delete_object(Bucket=mock_utils.TEST_BUCKET, Key=transaction_key)
 
 
-@time_machine.travel("2020-01-01 12:00:00", tick=False)
+@time_machine.travel("2020-01-01 12:00:00+00:00", tick=False)
 @mock.patch("src.site_upload.check_if_complete.check_if_complete.sleep", returns=time.sleep(1))
 def test_check_if_complete(mock_wait, mock_bucket, mock_notification, mock_glue):
     s3_client = boto3.client("s3", region_name="us-east-1")
@@ -90,7 +89,7 @@ def test_check_if_complete(mock_wait, mock_bucket, mock_notification, mock_glue)
                         }
                     ),
                     "TopicArn": mock_utils.TEST_COMPLETENESS_ARN,
-                    "Timestamp": datetime.now().isoformat(),
+                    "Timestamp": "2020-01-01 11:59:00+00:00",
                 },
             }
         ]
@@ -102,23 +101,23 @@ def test_check_if_complete(mock_wait, mock_bucket, mock_notification, mock_glue)
 
     # Upload a prior run of a study, but without the columns metadata - this function as
     # if a study has never been crawled before
-    with time_machine.travel("2019-12-12", tick=False):
+    with time_machine.travel("2019-12-12 12:00+00:00", tick=False):
         for file in transaction["cube"]:
             upload_file(file, mock_utils.EXISTING_VERSION, s3_client)
     res = check_if_complete.check_if_complete_handler(event, {})
     assert res["body"] == '"Processing not completed"'
 
     # one aggregate has finished, but another has not
-    with time_machine.travel("2020-01-01 12:01:00", tick=False):
+    with time_machine.travel("2020-01-01 12:01:00+00:00", tick=False):
         upload_file(transaction["cube"][0], mock_utils.EXISTING_VERSION, s3_client)
     res = check_if_complete.check_if_complete_handler(event, {})
     assert res["body"] == '"Processing not completed"'
 
     # All aggregates have finished, they are not in the db, so kick off a crawl
-    with time_machine.travel("2020-01-01 12:01:00", tick=False):
+    with time_machine.travel("2020-01-01 12:01:00+00:00", tick=False):
         for file in transaction["cube"] + transaction["flat"]:
             upload_file(file, mock_utils.EXISTING_VERSION, s3_client)
-    with time_machine.travel("2020-01-01 12:02:00", tick=False):
+    with time_machine.travel("2020-01-01 12:02:00+00:00", tick=False):
         with mock.patch("awswrangler.athena.read_sql_query") as query:
             query.return_value = pandas.DataFrame(data={"table_name": []})
             res = check_if_complete.check_if_complete_handler(event, {})
@@ -131,7 +130,7 @@ def test_check_if_complete(mock_wait, mock_bucket, mock_notification, mock_glue)
 
     # Throw an error when the crawler is stuck in the running state.
     reset_state(s3_client, transaction)
-    with time_machine.travel("2020-01-01 12:02:00", tick=False):
+    with time_machine.travel("2020-01-01 12:02:00+00:00", tick=False):
         with mock.patch("awswrangler.athena.read_sql_query") as query:
             query.return_value = pandas.DataFrame(data={"table_name": []})
             res = check_if_complete.check_if_complete_handler(event, {})
@@ -140,7 +139,7 @@ def test_check_if_complete(mock_wait, mock_bucket, mock_notification, mock_glue)
     # All aggregates have finished, they are not in the db, but a crawl has already started
 
     g_client.list_crawls(CrawlerName="cumulus-aggregator-test-crawler")
-    with time_machine.travel("2020-01-01 12:02:00", tick=False):
+    with time_machine.travel("2020-01-01 12:02:00+00:00", tick=False):
         with mock.patch("awswrangler.athena.read_sql_query") as query:
             with mock.patch(
                 "src.site_upload.check_if_complete.check_if_complete.mock_entrypoint"
@@ -159,7 +158,7 @@ def test_check_if_complete(mock_wait, mock_bucket, mock_notification, mock_glue)
 
     # The tables are now in the DB, so no crawl is required
     reset_state(s3_client, transaction)
-    with time_machine.travel("2020-01-01 12:02:00", tick=False):
+    with time_machine.travel("2020-01-01 12:02:00+00:00", tick=False):
         with mock.patch("awswrangler.athena.read_sql_query") as query:
             query.return_value = pandas.DataFrame(data={"table_name": expected_tables})
             res = check_if_complete.check_if_complete_handler(event, {})
@@ -175,9 +174,10 @@ def test_check_if_complete(mock_wait, mock_bucket, mock_notification, mock_glue)
     # moto's mocking of crawlers
     reset_state(s3_client, transaction)
     g_client.list_crawls(CrawlerName="cumulus-aggregator-test-crawler")
-    with mock.patch("awswrangler.athena.read_sql_query") as query:
-        query.return_value = pandas.DataFrame(data={"table_name": []})
-        res = check_if_complete.check_if_complete_handler(event, {})
+    with time_machine.travel("2020-01-01 12:02:00+00:00", tick=False):
+        with mock.patch("awswrangler.athena.read_sql_query") as query:
+            query.return_value = pandas.DataFrame(data={"table_name": []})
+            res = check_if_complete.check_if_complete_handler(event, {})
     body = (
         "Recrawl request for {"
         f"'site': '{mock_utils.EXISTING_SITE}', 'study': '{mock_utils.NEW_STUDY}'"
@@ -202,7 +202,7 @@ def test_check_if_complete(mock_wait, mock_bucket, mock_notification, mock_glue)
 
     reset_state(s3_client, transaction)
 
-    with time_machine.travel("2020-01-01 12:03:00", tick=False):
+    with time_machine.travel("2020-01-01 12:03:00+00:00", tick=False):
         with mock.patch("awswrangler.athena.read_sql_query") as query:
             with mock.patch(
                 "src.site_upload.check_if_complete.check_if_complete.mock_entrypoint"

--- a/tests/site_upload/test_check_if_complete.py
+++ b/tests/site_upload/test_check_if_complete.py
@@ -5,7 +5,7 @@ from unittest import mock
 
 import boto3
 import pandas
-from freezegun import freeze_time
+import time_machine
 
 from src.shared import enums, functions
 from src.site_upload.check_if_complete import check_if_complete
@@ -62,7 +62,7 @@ def delete_transaction():
     s3_client.delete_object(Bucket=mock_utils.TEST_BUCKET, Key=transaction_key)
 
 
-@freeze_time("2020-01-01 12:00:00")
+@time_machine.travel("2020-01-01 12:00:00", tick=False)
 @mock.patch("src.site_upload.check_if_complete.check_if_complete.sleep", returns=time.sleep(1))
 def test_check_if_complete(mock_wait, mock_bucket, mock_notification, mock_glue):
     s3_client = boto3.client("s3", region_name="us-east-1")
@@ -102,23 +102,23 @@ def test_check_if_complete(mock_wait, mock_bucket, mock_notification, mock_glue)
 
     # Upload a prior run of a study, but without the columns metadata - this function as
     # if a study has never been crawled before
-    with freeze_time("2019-12-12"):
+    with time_machine.travel("2019-12-12", tick=False):
         for file in transaction["cube"]:
             upload_file(file, mock_utils.EXISTING_VERSION, s3_client)
     res = check_if_complete.check_if_complete_handler(event, {})
     assert res["body"] == '"Processing not completed"'
 
     # one aggregate has finished, but another has not
-    with freeze_time("2020-01-01 12:01:00"):
+    with time_machine.travel("2020-01-01 12:01:00", tick=False):
         upload_file(transaction["cube"][0], mock_utils.EXISTING_VERSION, s3_client)
     res = check_if_complete.check_if_complete_handler(event, {})
     assert res["body"] == '"Processing not completed"'
 
     # All aggregates have finished, they are not in the db, so kick off a crawl
-    with freeze_time("2020-01-01 12:01:00"):
+    with time_machine.travel("2020-01-01 12:01:00", tick=False):
         for file in transaction["cube"] + transaction["flat"]:
             upload_file(file, mock_utils.EXISTING_VERSION, s3_client)
-    with freeze_time("2020-01-01 12:02:00"):
+    with time_machine.travel("2020-01-01 12:02:00", tick=False):
         with mock.patch("awswrangler.athena.read_sql_query") as query:
             query.return_value = pandas.DataFrame(data={"table_name": []})
             res = check_if_complete.check_if_complete_handler(event, {})
@@ -131,7 +131,7 @@ def test_check_if_complete(mock_wait, mock_bucket, mock_notification, mock_glue)
 
     # Throw an error when the crawler is stuck in the running state.
     reset_state(s3_client, transaction)
-    with freeze_time("2020-01-01 12:02:00"):
+    with time_machine.travel("2020-01-01 12:02:00", tick=False):
         with mock.patch("awswrangler.athena.read_sql_query") as query:
             query.return_value = pandas.DataFrame(data={"table_name": []})
             res = check_if_complete.check_if_complete_handler(event, {})
@@ -140,7 +140,7 @@ def test_check_if_complete(mock_wait, mock_bucket, mock_notification, mock_glue)
     # All aggregates have finished, they are not in the db, but a crawl has already started
 
     g_client.list_crawls(CrawlerName="cumulus-aggregator-test-crawler")
-    with freeze_time("2020-01-01 12:02:00"):
+    with time_machine.travel("2020-01-01 12:02:00", tick=False):
         with mock.patch("awswrangler.athena.read_sql_query") as query:
             with mock.patch(
                 "src.site_upload.check_if_complete.check_if_complete.mock_entrypoint"
@@ -159,7 +159,7 @@ def test_check_if_complete(mock_wait, mock_bucket, mock_notification, mock_glue)
 
     # The tables are now in the DB, so no crawl is required
     reset_state(s3_client, transaction)
-    with freeze_time("2020-01-01 12:02:00"):
+    with time_machine.travel("2020-01-01 12:02:00", tick=False):
         with mock.patch("awswrangler.athena.read_sql_query") as query:
             query.return_value = pandas.DataFrame(data={"table_name": expected_tables})
             res = check_if_complete.check_if_complete_handler(event, {})
@@ -187,7 +187,7 @@ def test_check_if_complete(mock_wait, mock_bucket, mock_notification, mock_glue)
 
     # There are no new data packages, so we can skip crawling.
     reset_state(s3_client, transaction)
-    with freeze_time("2020-01-01 12:03:00"):
+    with time_machine.travel("2020-01-01 12:03:00", tick=False):
         with mock.patch("awswrangler.athena.read_sql_query") as query:
             query.return_value = pandas.DataFrame(data={"table_name": expected_tables})
             res = check_if_complete.check_if_complete_handler(event, {})
@@ -202,7 +202,7 @@ def test_check_if_complete(mock_wait, mock_bucket, mock_notification, mock_glue)
 
     reset_state(s3_client, transaction)
 
-    with freeze_time("2020-01-01 12:03:00"):
+    with time_machine.travel("2020-01-01 12:03:00", tick=False):
         with mock.patch("awswrangler.athena.read_sql_query") as query:
             with mock.patch(
                 "src.site_upload.check_if_complete.check_if_complete.mock_entrypoint"

--- a/tests/site_upload/test_powerset_merge.py
+++ b/tests/site_upload/test_powerset_merge.py
@@ -6,7 +6,7 @@ import awswrangler
 import boto3
 import pandas
 import pytest
-from freezegun import freeze_time
+import time_machine
 from pandas import read_parquet
 
 from src.shared import enums, functions
@@ -14,7 +14,7 @@ from src.site_upload.powerset_merge import powerset_merge
 from tests import mock_utils
 
 
-@freeze_time("2020-01-01")
+@time_machine.travel("2020-01-01", tick=False)
 @pytest.mark.parametrize(
     "upload_file,study,site,data_package,version,filename,archives,duplicates,status,expected_contents,expected_rows,first_row,last_row",
     [
@@ -271,7 +271,7 @@ def test_powerset_merge_single_upload(
         assert "column_types_format_version" in c_updates[study][data_package][dp_id].keys()
 
 
-@freeze_time("2020-01-01")
+@time_machine.travel("2020-01-01", tick=False)
 @pytest.mark.parametrize(
     "upload_file,archives,expected_errors",
     [

--- a/tests/site_upload/test_process_upload.py
+++ b/tests/site_upload/test_process_upload.py
@@ -3,14 +3,14 @@ from datetime import UTC, datetime
 
 import boto3
 import pytest
-from freezegun import freeze_time
+import time_machine
 
 from src.shared import enums, functions
 from src.site_upload.process_upload import process_upload
 from tests import mock_utils
 
 
-@freeze_time("2020-01-01")
+@time_machine.travel("2020-01-01", tick=False)
 @pytest.mark.parametrize(
     "upload_file,study,data_package,site,version,filename,status,expected_contents",
     [

--- a/tests/site_upload/test_study_period.py
+++ b/tests/site_upload/test_study_period.py
@@ -3,14 +3,14 @@ from datetime import UTC, datetime
 
 import boto3
 import pytest
-from freezegun import freeze_time
+import time_machine
 
 from src.shared import enums, functions
 from src.site_upload.study_period import study_period
 from tests import mock_utils
 
 
-@freeze_time("2020-01-01")
+@time_machine.travel("2020-01-01", tick=False)
 @pytest.mark.parametrize(
     "upload_file,upload_path,event_key,multiple_files,status",
     [

--- a/tests/site_upload/test_unzip_upload.py
+++ b/tests/site_upload/test_unzip_upload.py
@@ -1,13 +1,13 @@
 import boto3
 import pytest
-from freezegun import freeze_time
+import time_machine
 
 from src.shared import enums, functions
 from src.site_upload.unzip_upload import unzip_upload
 from tests import mock_utils
 
 
-@freeze_time("2020-01-01")
+@time_machine.travel("2020-01-01", tick=False)
 @pytest.mark.parametrize(
     "upload_file,site,study,version,status,expected_contents",
     [

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -17,8 +17,8 @@ from unittest import mock
 import boto3
 import pandas
 import pytest
+import time_machine
 import toml
-from freezegun import freeze_time
 from moto.core import DEFAULT_ACCOUNT_ID
 from moto.sns import sns_backends
 
@@ -38,7 +38,7 @@ from tests import mock_utils
 CURRENT_COL_TYPES_VERSION = "3"
 
 
-@freeze_time("2025-06-06")
+@time_machine.travel("2025-06-06", tick=False)
 @pytest.mark.parametrize(
     "upload_file,upload_type,study,site,data_package,version,existing,run_migration",
     [


### PR DESCRIPTION
This updates the aggregator to use V6 of the library. As a byproduct of this change, it swaps out `freeze_time` for `time_machine`, to avoid issues mocking the datetime class directly.