### PR TITLE
Added table metadata processing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ version = "0.3.0"
 # The project dependencies are handled via AWS layers. These are only required for
 # local development.
 dependencies= [
+    "aiobotocore == 3.6.0", # version scanning for aiobotocore is causing issues in CI
     "arrow >=1.2.3",
     "awswrangler >=3.5, <4",
     "boto3 < 1.43.13", 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.3.0"
 dependencies= [
     "arrow >=1.2.3",
     "awswrangler >=3.5, <4",
-    "boto3",
+    "boto3 < 1.43.13", 
     "cumulus-library >=6, < 7",
     "Jinja2 >=3.1.4, <4",
     "pandas >=2.3.3, <3",

--- a/src/dashboard/get_chart_data/templates/get_chart_data.sql.jinja
+++ b/src/dashboard/get_chart_data/templates/get_chart_data.sql.jinja
@@ -1,6 +1,6 @@
 {%- import 'syntax.sql.jinja' as syntax -%}
 {%- import 'filter_inline.sql.jinja' as inline -%}
-SELECT 
+SELECT
     {%- if stratifier_column %}
         "{{ stratifier_column }}",
     {%- endif %}

--- a/src/dashboard/get_study_data/get_study_data.py
+++ b/src/dashboard/get_study_data/get_study_data.py
@@ -25,12 +25,19 @@ def study_data_handler(event, context):
     # In the future, we'll want to cache this data someplace, and hydrate it with other
     # sources, like data package info.
     payload = functions.get_s3_json_as_dict(
-        bucket=s3_bucket, key=f"{enums.BucketPath.CACHE}/studies.json", s3_client=s3_client
+        bucket=s3_bucket,
+        key=f"{enums.BucketPath.CACHE}/{enums.JsonFilename.STUDIES.value}.json",
+        s3_client=s3_client,
     )
-    if study:
-        payload = payload[study]
-        if version:
-            payload = payload[version]
-
+    try:
+        if study:
+            payload = payload[study]
+            if version:
+                if version == "@latest":
+                    payload = payload[sorted(payload.keys())[-1]]
+                else:
+                    payload = payload[version]
+    except KeyError:
+        return functions.http_response(404, "Not found", allow_cors=True)
     res = functions.http_response(200, payload, allow_cors=True)
     return res

--- a/src/site_upload/cache_api/cache_api.py
+++ b/src/site_upload/cache_api/cache_api.py
@@ -9,20 +9,17 @@ import boto3
 from shared import decorators, enums, functions
 
 
-def cache_api_data(s3_client, s3_bucket_name: str, db: str, target: str) -> None:
-    """Performs caching of API data"""
-    if target == enums.JsonFilename.DATA_PACKAGES.value:
-        df = awswrangler.athena.read_sql_query(
-            (
-                f"SELECT table_name FROM information_schema.tables "  # noqa: S608
-                f"WHERE table_schema = '{db}'"  # nosec
-            ),
-            database=db,
-            s3_output=f"s3://{s3_bucket_name}/awswrangler",
-            workgroup=os.environ.get("WORKGROUP_NAME"),
-        )
-    else:
-        raise KeyError("Invalid API caching target")
+def cache_data_packages(s3_client, s3_bucket_name: str, db: str):
+    """Creates a cache of data package metadata information"""
+    df = awswrangler.athena.read_sql_query(
+        (
+            f"SELECT table_name FROM information_schema.tables "  # noqa: S608
+            f"WHERE table_schema = '{db}'"  # nosec
+        ),
+        database=db,
+        s3_output=f"s3://{s3_bucket_name}/awswrangler",
+        workgroup=os.environ.get("WORKGROUP_NAME"),
+    )
     # this filters out system tables
     data_packages = df[df["table_name"].str.contains("__")].iloc[:, 0]
     column_types = functions.get_s3_json_as_dict(
@@ -96,6 +93,48 @@ def cache_api_data(s3_client, s3_bucket_name: str, db: str, target: str) -> None
         Key=f"{enums.BucketPath.CACHE.value}/{enums.JsonFilename.STUDIES.value}.json",
         Body=json.dumps(studies, indent=2),
     )
+
+
+def cache_study_data(s3_client, s3_bucket_name: str, db: str) -> None:
+    """Creates a cache of study metadata information"""
+    manifest_keys = functions.get_s3_keys(
+        s3_bucket_name=s3_bucket_name, prefix=enums.BucketPath.MANIFEST.value, s3_client=s3_client
+    )
+    manifest_keys = [x for x in manifest_keys if x.endswith(".json")]
+    studies = {}
+    for key in manifest_keys:
+        dp = functions.parse_s3_key(key)
+        if dp.study not in studies.keys():
+            studies[dp.study] = {}
+        manifest = functions.get_s3_json_as_dict(
+            bucket=s3_bucket_name, key=key, s3_client=s3_client
+        )
+        # we'll flatten the manifest table metadata for the api
+        manifest["tables"] = {}
+        for stage in manifest.get("stages", []):
+            for action in manifest["stages"][stage]:
+                if "tables" in action.keys():
+                    for table in action["tables"]:
+                        if isinstance(table, dict):
+                            manifest["tables"][table["name"]] = {
+                                "description": table["description"]
+                            }
+        manifest.pop("stages", None)
+        studies[dp.study][dp.version] = manifest
+    s3_client.put_object(
+        Bucket=s3_bucket_name,
+        Key=f"{enums.BucketPath.CACHE.value}/{enums.JsonFilename.STUDIES.value}.json",
+        Body=json.dumps(studies, indent=2),
+    )
+
+
+def cache_api_data(s3_client, s3_bucket_name: str, db: str, target: str) -> None:
+    """Performs caching of API data"""
+    if target == enums.JsonFilename.DATA_PACKAGES.value:
+        cache_data_packages(s3_client, s3_bucket_name, db)
+        cache_study_data(s3_client, s3_bucket_name, db)
+    else:
+        raise KeyError("Invalid API caching target")
 
 
 @decorators.generic_error_handler(msg="Error caching API responses")

--- a/template.yaml
+++ b/template.yaml
@@ -828,28 +828,34 @@ Resources:
         LogGroup: !Sub "/aws/lambda/CumulusAggDashboardGetStudyData-${DeployStage}-${NetworkName}"
       MemorySize: 128
       Timeout: 100
-      Description: Retrieve data about study descriptions
+      Description: Retrieve data about studies
       Environment:
         Variables:
           BUCKET_NAME: !Sub '${BucketNameParameter}-${AWS::AccountId}-${DeployStage}-${NetworkName}'
       Events:
-        GetStudyDataAPI:
+        GetStudiesAPI:
           Type: Api
           Properties:
             RestApiId: !Ref DashboardApiGateway
-            Path: /study
+            Path: /studies
             Method: GET
-        GetStudyDataStudyAPI:
+        GetStudStudyAPI:
           Type: Api
           Properties:
             RestApiId: !Ref DashboardApiGateway
-            Path: /study/{study}
+            Path: /studies/{study}
             Method: GET
-        GetStudyDataStudyVersionAPI:
+        GetStudyVersionsAPI:
           Type: Api
           Properties:
             RestApiId: !Ref DashboardApiGateway
-            Path: /study/{study}/{version}
+            Path: /studies/{study}/versions/
+            Method: GET
+        GetStudyVersionAPI:
+          Type: Api
+          Properties:
+            RestApiId: !Ref DashboardApiGateway
+            Path: /studies/{study}/versions/{version}
             Method: GET
       Policies:
         - S3ReadPolicy:

--- a/tests/dashboard/test_get_study_data.py
+++ b/tests/dashboard/test_get_study_data.py
@@ -1,32 +1,76 @@
 import json
+import os
 
+import boto3
 import pytest
 
 from src.dashboard.get_study_data import get_study_data
+from src.shared import enums, functions
 from tests import mock_utils
+
+MOCK_STUDY_JSON_WITH_NEW = {
+    "other_study": {
+        "099": {
+            "study_owner": "st_elsewhere",
+            "study_prefix": "other_study",
+            "description": "version 099 of other_study",
+            "tables": {},
+        }
+    },
+    "study": {
+        "099": {
+            "study_owner": "princeton_plainsboro_teaching_hospital",
+            "study_prefix": "study",
+            "description": "version 099 of study",
+            "tables": {},
+        },
+        "100": {
+            "study_prefix": "test",
+            "description": "latest version",
+            "study_owner": "princeton_plainsboro_teaching_hospital",
+            "tables": {"test_table": {"description": "A test table"}},
+        },
+    },
+}
 
 
 @pytest.mark.parametrize(
     "params,status,expected",
     [
-        (None, 200, mock_utils.get_mock_study_data()),
+        (None, 200, MOCK_STUDY_JSON_WITH_NEW),
         (
             {"study": mock_utils.EXISTING_STUDY},
             200,
-            mock_utils.get_mock_study_data()[mock_utils.EXISTING_STUDY],
+            MOCK_STUDY_JSON_WITH_NEW[mock_utils.EXISTING_STUDY],
         ),
         (
             {"study": mock_utils.EXISTING_STUDY, "version": mock_utils.EXISTING_VERSION},
             200,
-            mock_utils.get_mock_study_data()[mock_utils.EXISTING_STUDY][
-                mock_utils.EXISTING_VERSION
-            ],
+            MOCK_STUDY_JSON_WITH_NEW[mock_utils.EXISTING_STUDY][mock_utils.EXISTING_VERSION],
         ),
-        ({"study": mock_utils.NEW_STUDY, "version": mock_utils.EXISTING_VERSION}, 500, None),
-        ({"study": mock_utils.EXISTING_STUDY, "version": mock_utils.NEW_VERSION}, 500, None),
+        (
+            {"study": mock_utils.EXISTING_STUDY, "version": mock_utils.NEW_VERSION},
+            200,
+            MOCK_STUDY_JSON_WITH_NEW[mock_utils.EXISTING_STUDY][mock_utils.NEW_VERSION],
+        ),
+        (
+            {"study": mock_utils.EXISTING_STUDY, "version": "@latest"},
+            200,
+            MOCK_STUDY_JSON_WITH_NEW[mock_utils.EXISTING_STUDY][mock_utils.NEW_VERSION],
+        ),
+        ({"study": mock_utils.NEW_STUDY, "version": mock_utils.EXISTING_VERSION}, 404, None),
+        ({"study": mock_utils.EXISTING_STUDY, "version": "bad_version"}, 404, None),
     ],
 )
 def test_get_study_data(mock_bucket, params, status, expected):
+    s3_bucket_name = os.environ.get("BUCKET_NAME")
+    s3_client = boto3.client("s3")
+    functions.put_s3_file(
+        s3_client=s3_client,
+        s3_bucket_name=s3_bucket_name,
+        key=f"{enums.BucketPath.CACHE.value}/{enums.JsonFilename.STUDIES.value}.json",
+        payload=MOCK_STUDY_JSON_WITH_NEW,
+    )
     event = {"pathParameters": params}
     res = get_study_data.study_data_handler(event, {})
     assert res["statusCode"] == status

--- a/tests/site_upload/test_cache_api.py
+++ b/tests/site_upload/test_cache_api.py
@@ -6,13 +6,13 @@ import boto3
 import pandas
 import pytest
 
-from src.shared import enums
+from src.shared import enums, functions
 from src.site_upload.cache_api import cache_api
-from tests.mock_utils import MOCK_ENV, get_mock_data_packages_cache
+from tests import mock_utils
 
 
 def mock_data_packages(*args, **kwargs):
-    return pandas.DataFrame(get_mock_data_packages_cache(), columns=["table_name"])
+    return pandas.DataFrame(mock_utils.get_mock_data_packages_cache(), columns=["table_name"])
 
 
 def mock_event(source, subject, message):
@@ -57,7 +57,10 @@ def test_cache_api_data(mock_bucket):
     s3_bucket_name = os.environ.get("BUCKET_NAME")
     s3_client = boto3.client("s3")
     cache_api.cache_api_data(
-        s3_client, s3_bucket_name, MOCK_ENV["GLUE_DB_NAME"], enums.JsonFilename.DATA_PACKAGES.value
+        s3_client,
+        s3_bucket_name,
+        mock_utils.MOCK_ENV["GLUE_DB_NAME"],
+        enums.JsonFilename.DATA_PACKAGES.value,
     )
     cache = json.loads(
         s3_client.get_object(
@@ -88,3 +91,68 @@ def test_cache_api_data(mock_bucket):
             "version": "099",
         }
     ]
+
+
+def test_cache_study_data(mock_bucket):
+    s3_bucket_name = os.environ.get("BUCKET_NAME")
+    s3_client = boto3.client("s3")
+    functions.put_s3_file(
+        s3_client=s3_client,
+        s3_bucket_name=s3_bucket_name,
+        key=(
+            f"{enums.BucketPath.MANIFEST.value}/{mock_utils.EXISTING_STUDY}/"
+            f"{mock_utils.NEW_VERSION}/manifest.json"
+        ),
+        payload={
+            "study_prefix": "test",
+            "description": "latest version",
+            "stages": {
+                "default": [
+                    {
+                        "type": "export:counts",
+                        "tables": [
+                            {"name": "test_table", "description": "A test table"},
+                        ],
+                    }
+                ]
+            },
+            "study_owner": "princeton_plainsboro_teaching_hospital",
+        },
+    )
+    cache_api.cache_study_data(
+        s3_client,
+        s3_bucket_name,
+        mock_utils.MOCK_ENV["GLUE_DB_NAME"],
+    )
+    cache = json.loads(
+        s3_client.get_object(
+            Bucket=s3_bucket_name,
+            Key=f"{enums.BucketPath.CACHE.value}/{enums.JsonFilename.STUDIES.value}.json",
+        )["Body"]
+        .read()
+        .decode("UTF-8")
+    )
+    assert cache == {
+        "other_study": {
+            "099": {
+                "study_owner": "st_elsewhere",
+                "study_prefix": "other_study",
+                "description": "version 099 of other_study",
+                "tables": {},
+            }
+        },
+        "study": {
+            "099": {
+                "study_owner": "princeton_plainsboro_teaching_hospital",
+                "study_prefix": "study",
+                "description": "version 099 of study",
+                "tables": {},
+            },
+            "100": {
+                "study_prefix": "test",
+                "description": "latest version",
+                "study_owner": "princeton_plainsboro_teaching_hospital",
+                "tables": {"test_table": {"description": "A test table"}},
+            },
+        },
+    }


### PR DESCRIPTION
This adds handling of the new table metadata to the API caching, and adds a '@latest' keyword to the get study data endpoint. It also lightly reorgs the endpoint structure.

Partially addresses #220.