### PR TITLE
Add data dictionary processing

### DIFF
--- a/scripts/credential_management.py
+++ b/scripts/credential_management.py
@@ -34,11 +34,11 @@ def create_auth(user: str, auth: str, site: str) -> str:
     return f'"{site_id}": {{"user": "{user}", "site":"{site}"}}'
 
 
-def create_meta(client, bucket_name: str, site: str, folder: str) -> None:
+def create_meta(client, bucket_name: str, site: str, folder: str, display: str) -> None:
     """Adds an entry to the metadata dictionary for routing files"""
     file = "metadata.json"
     meta_dict = _get_s3_data(file, bucket_name, client)
-    meta_dict[site] = {"path": folder}
+    meta_dict[site] = {"path": folder, "display": display}
     _put_s3_data(file, bucket_name, client, meta_dict)
 
 
@@ -79,7 +79,7 @@ if __name__ == "__main__":
         "--create-meta",
         action="extend",
         nargs="+",
-        help="Create metadata. Expects: Site Folder",
+        help="Create metadata. Expects: Site Folder Display",
     )
     s3_modification.add_argument("--delete-meta", help="Delete metadata. Expects: Site")
     args = parser.parse_args()
@@ -96,7 +96,9 @@ if __name__ == "__main__":
         )
         print(f"Add the following key/value to secrets manager: \n {id_str}")
     elif args.create_meta:
-        create_meta(s3_client, args.bucket, args.create_meta[0], args.create_meta[1])
+        create_meta(
+            s3_client, args.bucket, args.create_meta[0], args.create_meta[1], args.create_meta[2]
+        )
         print(f"{args.create_meta[0]} mapped to S3 folder {args.create_meta[1]}")
     elif args.delete_meta:
         succeeded = delete_meta(s3_client, args.bucket, args.delete_meta)

--- a/src/dashboard/get_study_data/get_study_data.py
+++ b/src/dashboard/get_study_data/get_study_data.py
@@ -17,13 +17,12 @@ def study_data_handler(event, context):
     if event["pathParameters"] is not None:
         study = event["pathParameters"].get("study")
         version = event["pathParameters"].get("version")
+        table = event["pathParameters"].get("table")
     else:
         study = None
         version = None
+        table = None
 
-    # This is currently focused on just getting the data out from the cached manifests.
-    # In the future, we'll want to cache this data someplace, and hydrate it with other
-    # sources, like data package info.
     payload = functions.get_s3_json_as_dict(
         bucket=s3_bucket,
         key=f"{enums.BucketPath.CACHE}/{enums.JsonFilename.STUDIES.value}.json",
@@ -37,6 +36,13 @@ def study_data_handler(event, context):
                     payload = payload[sorted(payload.keys())[-1]]
                 else:
                     payload = payload[version]
+
+                if "/dictionary" in event["path"]:
+                    payload = payload.get("data_dictionary", [])
+                elif "/tables" in event["path"]:
+                    payload = payload["tables"]
+                    if table:
+                        payload = payload[table]
     except KeyError:
         return functions.http_response(404, "Not found", allow_cors=True)
     res = functions.http_response(200, payload, allow_cors=True)

--- a/src/shared/functions.py
+++ b/src/shared/functions.py
@@ -339,7 +339,12 @@ class PackageMetadata:
                     f"Files in {subbucket} do not have an expected filename"
                 )
 
-    def get_tablename(self, subbucket: enum.StrEnum):
+    def get_tablename(self, subbucket: enum.StrEnum | None = None):
+        if subbucket is None:
+            if len(self.filename.split("__")) == 4:
+                subbucket = enums.BucketPath.FLAT
+            else:
+                subbucket = enums.BucketPath.AGGREGATE
         match subbucket:
             case enums.BucketPath.AGGREGATE:
                 return f"{self.study}__{self.data_package}__{self.version}"

--- a/src/site_upload/cache_api/cache_api.py
+++ b/src/site_upload/cache_api/cache_api.py
@@ -95,10 +95,34 @@ def cache_data_packages(s3_client, s3_bucket_name: str, db: str):
     )
 
 
+def _get_metadata_from_table(table: dict, study_cols: dict, dp: dict, data_dict: dict) -> dict:
+    output = {"description": table["description"], "columns": {}}
+    # Note: we can't use dp.data_package here - we have the manifest, not
+    # a path to a file
+
+    table_cols = study_cols[table["name"].split("__")[1]][f"{table['name']}__{dp.version}"][
+        "columns"
+    ]
+    for col, details in table_cols.items():
+        output["columns"][col] = table_cols[col]
+        col_type = next((x for x in data_dict if x["name"] == col), {})
+        for key in col_type:
+            output["columns"][col][key] = col_type[key]
+    return output
+
+
 def cache_study_data(s3_client, s3_bucket_name: str, db: str) -> None:
     """Creates a cache of study metadata information"""
     manifest_keys = functions.get_s3_keys(
         s3_bucket_name=s3_bucket_name, prefix=enums.BucketPath.MANIFEST.value, s3_client=s3_client
+    )
+    column_types = functions.get_s3_json_as_dict(
+        os.environ.get("BUCKET_NAME"),
+        f"{enums.BucketPath.META.value}/{enums.JsonFilename.COLUMN_TYPES.value}.json",
+    )
+    site_info = functions.get_s3_json_as_dict(
+        os.environ.get("BUCKET_NAME"),
+        f"{enums.BucketPath.ADMIN.value}/metadata.json",
     )
     manifest_keys = [x for x in manifest_keys if x.endswith(".json")]
     studies = {}
@@ -106,9 +130,25 @@ def cache_study_data(s3_client, s3_bucket_name: str, db: str) -> None:
         dp = functions.parse_s3_key(key)
         if dp.study not in studies.keys():
             studies[dp.study] = {}
+        study_cols = column_types[dp.study]
         manifest = functions.get_s3_json_as_dict(
             bucket=s3_bucket_name, key=key, s3_client=s3_client
         )
+        owning_site_info = next(
+            (
+                site_info[x]
+                for x in site_info.keys()
+                if site_info[x]["path"] == manifest.get("study_owner")
+            ),
+            {"foo": "bar"},
+        )
+        print("site info", site_info)
+        print("manifest", manifest)
+        print("owner", owning_site_info)
+        if display := owning_site_info.get("display"):
+            manifest["study_owner_display"] = display
+        else:  # pragma: no cover
+            manifest["study_owner_display"] = manifest["study_owner"]
         # we'll flatten the manifest table metadata for the api
         manifest["tables"] = {}
         for stage in manifest.get("stages", []):
@@ -116,9 +156,10 @@ def cache_study_data(s3_client, s3_bucket_name: str, db: str) -> None:
                 if "tables" in action.keys():
                     for table in action["tables"]:
                         if isinstance(table, dict):
-                            manifest["tables"][table["name"]] = {
-                                "description": table["description"]
-                            }
+                            manifest["tables"][table["name"]] = _get_metadata_from_table(
+                                table, study_cols, dp, manifest.get("data_dictionary", {})
+                            )
+
         manifest.pop("stages", None)
         studies[dp.study][dp.version] = manifest
     s3_client.put_object(

--- a/src/site_upload/process_manifest/process_manifest.py
+++ b/src/site_upload/process_manifest/process_manifest.py
@@ -12,7 +12,6 @@ logger.setLevel(log_level)
 def process_manifest(manager: s3_manager.S3Manager):
     key = manager.s3_key
     manifest = manager.get_manifest()
-    print(manifest)
     if manifest != {}:
         # Is this upload from someone other than the owning institution?
         if manifest["study_owner"] != manager.site:

--- a/template.yaml
+++ b/template.yaml
@@ -857,6 +857,24 @@ Resources:
             RestApiId: !Ref DashboardApiGateway
             Path: /studies/{study}/versions/{version}
             Method: GET
+        GetStudyVersionDataDictAPI:
+          Type: Api
+          Properties:
+            RestApiId: !Ref DashboardApiGateway
+            Path: /studies/{study}/versions/{version}/dictionary
+            Method: GET
+        GetStudyVersionTablesAPI:
+          Type: Api
+          Properties:
+            RestApiId: !Ref DashboardApiGateway
+            Path: /studies/{study}/versions/{version}/tables
+            Method: GET
+        GetStudyVersionTableAPI:
+          Type: Api
+          Properties:
+            RestApiId: !Ref DashboardApiGateway
+            Path: /studies/{study}/versions/{version}/tables/{table}
+            Method: GET
       Policies:
         - S3ReadPolicy:
             BucketName: !Sub '${BucketNameParameter}-${AWS::AccountId}-${DeployStage}-${NetworkName}'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,10 +130,16 @@ def mock_bucket():
         _init_mock_data(s3_client, bucket, *param_list)
 
     credential_management.create_meta(
-        s3_client, bucket, "ppth", "princeton_plainsboro_teaching_hospital"
+        s3_client,
+        bucket,
+        "ppth",
+        "princeton_plainsboro_teaching_hospital",
+        "Princeton Plainsboro Teaching Hospital",
     )
-    credential_management.create_meta(s3_client, bucket, "elsewhere", "st_elsewhere")
-    credential_management.create_meta(s3_client, bucket, "hope", "chicago_hope")
+    credential_management.create_meta(
+        s3_client, bucket, "elsewhere", "st_elsewhere", "Saint Elsewhere"
+    )
+    credential_management.create_meta(s3_client, bucket, "hope", "chicago_hope", "Chicago Hope")
 
     for meta_type, source in [
         [enums.JsonFilename.TRANSACTIONS.value, mock_utils.get_mock_metadata()],

--- a/tests/dashboard/test_get_study_data.py
+++ b/tests/dashboard/test_get_study_data.py
@@ -13,56 +13,98 @@ MOCK_STUDY_JSON_WITH_NEW = {
         "099": {
             "study_owner": "st_elsewhere",
             "study_prefix": "other_study",
+            "study_owner_display": "Saint Elsewhere",
             "description": "version 099 of other_study",
-            "tables": {},
+            "tables": {"test_table_1": {"description": "A test table"}},
+            "data_dictionary": [{"name": "foo"}],
         }
     },
     "study": {
         "099": {
             "study_owner": "princeton_plainsboro_teaching_hospital",
+            "study_owner_display": "Princeton Plainsboro Teaching Hospital",
             "study_prefix": "study",
             "description": "version 099 of study",
-            "tables": {},
+            "data_dictionary": [{"name": "bar"}],
+            "tables": {"test_table_2": {"description": "A test table"}},
         },
         "100": {
             "study_prefix": "test",
             "description": "latest version",
             "study_owner": "princeton_plainsboro_teaching_hospital",
-            "tables": {"test_table": {"description": "A test table"}},
+            "study_owner_display": "Princeton Plainsboro Teaching Hospital",
+            "data_dictionary": [{"name": "baz"}],
+            "tables": {"test_table_3": {"description": "A test table"}},
         },
     },
 }
 
 
 @pytest.mark.parametrize(
-    "params,status,expected",
+    "path,params,status,expected",
     [
-        (None, 200, MOCK_STUDY_JSON_WITH_NEW),
+        ("/", None, 200, MOCK_STUDY_JSON_WITH_NEW),
         (
+            f"/studies/{mock_utils.EXISTING_STUDY}",
             {"study": mock_utils.EXISTING_STUDY},
             200,
             MOCK_STUDY_JSON_WITH_NEW[mock_utils.EXISTING_STUDY],
         ),
         (
+            f"/studies/{mock_utils.EXISTING_STUDY}/versions/{mock_utils.EXISTING_VERSION}",
             {"study": mock_utils.EXISTING_STUDY, "version": mock_utils.EXISTING_VERSION},
             200,
             MOCK_STUDY_JSON_WITH_NEW[mock_utils.EXISTING_STUDY][mock_utils.EXISTING_VERSION],
         ),
         (
+            f"/studies/{mock_utils.EXISTING_STUDY}/versions/{mock_utils.NEW_VERSION}",
             {"study": mock_utils.EXISTING_STUDY, "version": mock_utils.NEW_VERSION},
             200,
             MOCK_STUDY_JSON_WITH_NEW[mock_utils.EXISTING_STUDY][mock_utils.NEW_VERSION],
         ),
         (
+            f"/studies/{mock_utils.EXISTING_STUDY}/versions/@latest",
             {"study": mock_utils.EXISTING_STUDY, "version": "@latest"},
             200,
             MOCK_STUDY_JSON_WITH_NEW[mock_utils.EXISTING_STUDY][mock_utils.NEW_VERSION],
         ),
-        ({"study": mock_utils.NEW_STUDY, "version": mock_utils.EXISTING_VERSION}, 404, None),
-        ({"study": mock_utils.EXISTING_STUDY, "version": "bad_version"}, 404, None),
+        (
+            f"/studies/{mock_utils.EXISTING_STUDY}/versions/@latest/dictionary",
+            {"study": mock_utils.EXISTING_STUDY, "version": "@latest"},
+            200,
+            MOCK_STUDY_JSON_WITH_NEW[mock_utils.EXISTING_STUDY][mock_utils.NEW_VERSION][
+                "data_dictionary"
+            ],
+        ),
+        (
+            f"/studies/{mock_utils.EXISTING_STUDY}/versions/@latest/tables",
+            {"study": mock_utils.EXISTING_STUDY, "version": "@latest"},
+            200,
+            MOCK_STUDY_JSON_WITH_NEW[mock_utils.EXISTING_STUDY][mock_utils.NEW_VERSION]["tables"],
+        ),
+        (
+            f"/studies/{mock_utils.EXISTING_STUDY}/versions/@latest/tables/test_table_3",
+            {"study": mock_utils.EXISTING_STUDY, "version": "@latest", "table": "test_table_3"},
+            200,
+            MOCK_STUDY_JSON_WITH_NEW[mock_utils.EXISTING_STUDY][mock_utils.NEW_VERSION]["tables"][
+                "test_table_3"
+            ],
+        ),
+        (
+            f"/studies/{mock_utils.NEW_STUDY}/versions/{mock_utils.EXISTING_VERSION}",
+            {"study": mock_utils.NEW_STUDY, "version": mock_utils.EXISTING_VERSION},
+            404,
+            None,
+        ),
+        (
+            f"/studies/{mock_utils.NEW_STUDY}/versions/bad_version",
+            {"study": mock_utils.EXISTING_STUDY, "version": "bad_version"},
+            404,
+            None,
+        ),
     ],
 )
-def test_get_study_data(mock_bucket, params, status, expected):
+def test_get_study_data(mock_bucket, path, params, status, expected):
     s3_bucket_name = os.environ.get("BUCKET_NAME")
     s3_client = boto3.client("s3")
     functions.put_s3_file(
@@ -71,7 +113,7 @@ def test_get_study_data(mock_bucket, params, status, expected):
         key=f"{enums.BucketPath.CACHE.value}/{enums.JsonFilename.STUDIES.value}.json",
         payload=MOCK_STUDY_JSON_WITH_NEW,
     )
-    event = {"pathParameters": params}
+    event = {"pathParameters": params, "path": path}
     res = get_study_data.study_data_handler(event, {})
     assert res["statusCode"] == status
     if status == 200:

--- a/tests/site_upload/test_cache_api.py
+++ b/tests/site_upload/test_cache_api.py
@@ -101,22 +101,45 @@ def test_cache_study_data(mock_bucket):
         s3_bucket_name=s3_bucket_name,
         key=(
             f"{enums.BucketPath.MANIFEST.value}/{mock_utils.EXISTING_STUDY}/"
-            f"{mock_utils.NEW_VERSION}/manifest.json"
+            f"{mock_utils.EXISTING_VERSION}/manifest.json"
         ),
         payload={
-            "study_prefix": "test",
+            "study_prefix": mock_utils.EXISTING_STUDY,
             "description": "latest version",
             "stages": {
                 "default": [
                     {
                         "type": "export:counts",
                         "tables": [
-                            {"name": "test_table", "description": "A test table"},
+                            {"name": "study__encounter", "description": "A test table"},
                         ],
                     }
                 ]
             },
             "study_owner": "princeton_plainsboro_teaching_hospital",
+            "data_dictionary": [
+                {
+                    "name": "cnt",
+                    "display": "Count",
+                    "description": "A count of records matching the table definitions",
+                    "details": "",
+                    "type": "integer",
+                },
+                {
+                    "name": "gender",
+                    "display": "Gender",
+                    "description": "The patient's gender",
+                    "details": "Corresponds to http://hl7.org/fhir/ValueSet/administrative-gender",
+                    "type": "string",
+                },
+                {
+                    "name": "race_display",
+                    "display": "Race",
+                    "description": "The race the patient identified as",
+                    "details": "Corresponds to http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+                    "type": "string",
+                },
+            ],
         },
     )
     cache_api.cache_study_data(
@@ -138,21 +161,71 @@ def test_cache_study_data(mock_bucket):
                 "study_owner": "st_elsewhere",
                 "study_prefix": "other_study",
                 "description": "version 099 of other_study",
+                "study_owner_display": "Saint Elsewhere",
                 "tables": {},
             }
         },
         "study": {
             "099": {
-                "study_owner": "princeton_plainsboro_teaching_hospital",
                 "study_prefix": "study",
-                "description": "version 099 of study",
-                "tables": {},
-            },
-            "100": {
-                "study_prefix": "test",
                 "description": "latest version",
                 "study_owner": "princeton_plainsboro_teaching_hospital",
-                "tables": {"test_table": {"description": "A test table"}},
-            },
+                "data_dictionary": [
+                    {
+                        "name": "cnt",
+                        "display": "Count",
+                        "description": "A count of records matching the table definitions",
+                        "details": "",
+                        "type": "integer",
+                    },
+                    {
+                        "name": "gender",
+                        "display": "Gender",
+                        "description": "The patient's gender",
+                        "details": "Corresponds to http://hl7.org/fhir/ValueSet/administrative-gender",
+                        "type": "string",
+                    },
+                    {
+                        "name": "race_display",
+                        "display": "Race",
+                        "description": "The race the patient identified as",
+                        "details": "Corresponds to http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+                        "type": "string",
+                    },
+                ],
+                "study_owner_display": "Princeton Plainsboro Teaching Hospital",
+                "tables": {
+                    "study__encounter": {
+                        "description": "A test table",
+                        "columns": {
+                            "cnt": {
+                                "type": "integer",
+                                "name": "cnt",
+                                "display": "Count",
+                                "description": "A count of records matching the table definitions",
+                                "details": "",
+                            },
+                            "gender": {
+                                "type": "string",
+                                "distinct_values_count": 10,
+                                "name": "gender",
+                                "display": "Gender",
+                                "description": "The patient's gender",
+                                "details": "Corresponds to http://hl7.org/fhir/ValueSet/administrative-gender",
+                            },
+                            "age": {"type": "integer", "distinct_values_count": 10},
+                            "race_display": {
+                                "type": "string",
+                                "distinct_values_count": 10,
+                                "name": "race_display",
+                                "display": "Race",
+                                "description": "The race the patient identified as",
+                                "details": "Corresponds to http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+                            },
+                            "site": {"type": "string", "distinct_values_count": 10},
+                        },
+                    }
+                },
+            }
         },
     }


### PR DESCRIPTION
This PR adds the following features:
- Adds a data dictionary, if present, to the stashed copy of the manifest during an upload
- hydrates the column types metadata with matching entries from the data dictionary
- Adds new REST endpoints to the study endpoint to correspond to data dictionaries and table data
- Updates site metadata creation to add a site display string to the site metadata