### PR TITLE
Added html heartbeat service to APIs

### DIFF
--- a/src/shared/heartbeat.py
+++ b/src/shared/heartbeat.py
@@ -1,0 +1,39 @@
+"""Lambda for static HTML at API gateway root"""
+
+import os
+
+
+def heartbeat_handler(event, context):
+    """A static response indicating the proxy is up"""
+    del event
+    del context
+    display_name = os.environ.get("DISPLAY_NAME", "Heartbeat")
+    doc_url = os.environ.get("DOC_URL", "https://docs.smarthealthit.org/cumulus/")
+
+    response_body = f"""
+    <!DOCTYPE html>
+    <html lang="en">
+        <head>
+            <meta charset="UTF-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            <title>{display_name}</title>
+            <style>
+                body {{ font-family: sans-serif; margin: 2em; background: #f8f9fa; }}
+                h1 {{ color: #2c3e50; }}
+                a {{ margin: 1em 0; color: #007bff; text-decoration: none; }}
+                a:hover {{ text-decoration: underline; }}
+            </style>
+        </head>
+        <body>
+            <h1>{display_name}</h1>
+            <p> See the <a href ="{doc_url}">documentation site</a> for more info</p>
+        </body>
+    </html>
+    """
+    return {
+        "statusCode": 200,
+        "body": response_body,
+        "headers": {
+            "Content-Type": "text/html",
+        },
+    }

--- a/template.proxy.yaml
+++ b/template.proxy.yaml
@@ -26,6 +26,54 @@ Parameters:
 
 Resources:
 
+  SiteApiHeartbeatFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub 'CumulusAggSiteApiHeartbeat-${DeployStage}'
+      CodeUri: ./src/shared
+      Handler: heartbeat.heartbeat_handler
+      Runtime: "python3.11"
+      MemorySize: 128
+      Timeout: 100
+      Description: Provides a static response for testing availability of the API proxy
+      Environment:
+        Variables:
+          DISPLAY_NAME: !Sub 'Cumulus Site API proxy - ${DeployStage}'
+          DOC_URL: https://docs.smarthealthit.org/cumulus/library/sharing-data.html#uploading-data-to-cumulus-aggregator
+      Events:
+        SiteApiProxy:
+          Type: Api
+          Properties:
+            RestApiId: !Ref SiteApiProxy
+            Path: /
+            Method: GET
+
+  # TODO: It would be good to bind the lambda to the root resource directly,
+  # but this is surprisinly fussy to do given all the fiddly bits for 'extract
+  # part of a json payload and convert it to HTML'. We'll last mile that bit
+  # by hand for now just to unblock integration. Some WIP is below for future
+  # reference
+  
+  # SiteApiHeartbeatMethod:
+  #   Type: AWS::ApiGateway::Method
+  #   Properties:
+  #     RestApiId: !Ref SiteApiProxy
+  #     ResourceId: !GetAtt SiteApiProxy.RootResourceId
+  #     HttpMethod: GET
+  #     AuthorizationType: NONE
+  #     Integration:
+  #       IntegrationResponses:
+  #         - StatusCode: 200
+  #           ResponseTemplates:
+  #             text/html: "$input.path('body')"
+  #       IntegrationHttpMethod: POST
+  #       Type: AWS_PROXY
+  #     # MethodResponses:
+  #     #   - StatusCode: 200
+  #     #     ResponseParameters:
+  #     #       text/html: Empty
+
+
   SiteApiProxy:
     Type: AWS::ApiGateway::RestApi
     Properties:
@@ -80,6 +128,30 @@ Resources:
       LogGroupName: !Sub "/aws/apigateway/${SiteApiProxy}"
 
       RetentionInDays: !Ref RetentionTime
+
+  DashboardApiHeartbeatFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub 'CumulusAggDashboardApiHeartbeat-${DeployStage}'
+      CodeUri: ./src/shared
+      Handler: heartbeat.heartbeat_handler
+      Runtime: "python3.11"
+      MemorySize: 128
+      Timeout: 100
+      Description: Provides a static response for testing availability of the API proxy
+      Environment:
+        Variables:
+          DISPLAY_NAME: !Sub 'Cumulus Dashboard API proxy - ${DeployStage}'
+          DOC_URL: https://docs.smarthealthit.org/cumulus/aggregator/dashboard-api.html
+      Events:
+        DashboardApiProxy:
+          Type: Api
+          Properties:
+            RestApiId: !Ref DashboardApiProxy
+            Path: /
+            Method: GET
+
+
 
   DashboardApiProxy:
     Type: AWS::ApiGateway::RestApi

--- a/tests/shared/test_heartbeat.py
+++ b/tests/shared/test_heartbeat.py
@@ -1,0 +1,13 @@
+import os
+from unittest import mock
+
+from src.shared import heartbeat
+
+
+@mock.patch.dict(os.environ, {"DISPLAY_NAME": "Unit test", "DOC_URL": "http://test.com"})
+def test_heartbeat():
+    response = heartbeat.heartbeat_handler({}, {})
+    assert response["statusCode"] == 200
+    assert response["headers"]["Content-Type"] == "text/html"
+    assert "Unit test" in response["body"]
+    assert "test.com" in response["body"]


### PR DESCRIPTION
This adds a landing page to use at the base of each aggregator API to help assist in 'are we connected correctly' type debugging.

Note that I'm punting on the hard part to get this moving and I'll do the last mile via clickops.